### PR TITLE
Replace tick and spawn hooks

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/Mountable.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/Mountable.kt
@@ -59,8 +59,8 @@ class Mountable(val spider: Spider): SpiderComponent {
             }
         })
 
-        closable += onTick {
-            val player = getRider() ?: return@onTick
+        closable += onServerTick {
+            val player = getRider() ?: return@onServerTick
 
             val input = Vector()
             if (player.currentInput.isLeft) input.x += 1.0

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/CustomItem.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/CustomItem.kt
@@ -44,7 +44,7 @@ object CustomItemRegistry {
             if (customItem.isItem(item)) customItem.onRightClick?.invoke(player)
         }
 
-        onTick {
+        onServerTick {
             for (player in Bukkit.getServer().onlinePlayers) {
                 get(player.inventory.itemInMainHand)?.onHeldTick?.invoke(player)
                 get(player.inventory.itemInOffHand)?.onHeldTick?.invoke(player)


### PR DESCRIPTION
## Summary
- replace custom tick helper with `onServerTick` that hooks `TickEvent.ServerTickEvent`
- reimplement scheduler utilities with tick counters and add `EntityJoinLevelEvent` listener
- update item registry and mountable behavior to use new server tick helper

## Testing
- `gradle build` *(fails: Could not resolve org.spigotmc:spigot-api:1.21.3-R0.1-SNAPSHOT; Could not find net.minecraftforge:forge:1.20.1-47.3.0_mapped_official_1.20.1)*

------
https://chatgpt.com/codex/tasks/task_b_689484662f6483298a3f5da4d643afb6