### PR TITLE
Add Forge config and command permission checks

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -86,6 +86,8 @@ class ToggleDebugItem(properties: Properties) : Item(properties) {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
         val bukkitPlayer = toBukkit(player)
         AppState.showDebugVisuals = !AppState.showDebugVisuals
+        SpiderConfig.SHOW_DEBUG.set(AppState.showDebugVisuals)
+        SpiderConfig.save()
         AppState.chainVisualizer?.detailed = AppState.showDebugVisuals
         val pitch = if (AppState.showDebugVisuals) 2.0f else 1.5f
         playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, pitch)
@@ -146,6 +148,8 @@ class SwitchGaitItem(properties: Properties) : Item(properties) {
         val bukkitPlayer = toBukkit(player)
         playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, 2.0f)
         AppState.gallop = !AppState.gallop
+        SpiderConfig.GALLOP.set(AppState.gallop)
+        SpiderConfig.save()
         sendActionBar(bukkitPlayer, if (!AppState.gallop) "Walk mode" else "Gallop mode")
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }

--- a/src/main/kotlin/com/heledron/spideranimation/RegisterCommands.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/RegisterCommands.kt
@@ -31,6 +31,7 @@ fun registerCommands(event: RegisterCommandsEvent) {
 private fun registerScale(dispatcher: CommandDispatcher<CommandSourceStack>) {
     dispatcher.register(
         Commands.literal("scale")
+            .requires { it.hasPermission(2) }
             .then(
                 Commands.argument("scale", DoubleArgumentType.doubleArg())
                     .executes { ctx ->
@@ -58,6 +59,7 @@ private fun registerPreset(dispatcher: CommandDispatcher<CommandSourceStack>) {
 
     dispatcher.register(
         Commands.literal("preset")
+            .requires { it.hasPermission(2) }
             .then(
                 Commands.argument("name", StringArgumentType.word())
                     .suggests { _, builder ->
@@ -112,6 +114,7 @@ private fun applyPreset(
 private fun registerFall(dispatcher: CommandDispatcher<CommandSourceStack>) {
     dispatcher.register(
         Commands.literal("fall")
+            .requires { it.hasPermission(2) }
             .then(
                 Commands.argument("height", DoubleArgumentType.doubleArg())
                     .executes { ctx ->
@@ -127,6 +130,7 @@ private fun registerFall(dispatcher: CommandDispatcher<CommandSourceStack>) {
 private fun registerSplay(dispatcher: CommandDispatcher<CommandSourceStack>) {
     dispatcher.register(
         Commands.literal("splay")
+            .requires { it.hasPermission(2) }
             .then(
                 Commands.argument("delay", IntegerArgumentType.integer(0))
                     .executes { ctx ->

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
@@ -13,7 +13,9 @@ import net.minecraftforge.event.entity.EntityJoinLevelEvent
 import net.minecraftforge.event.server.ServerStartingEvent
 import net.minecraftforge.event.server.ServerStoppingEvent
 import net.minecraftforge.eventbus.api.SubscribeEvent
+import net.minecraftforge.fml.ModLoadingContext
 import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.config.ModConfig
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext
 import org.apache.logging.log4j.LogManager
@@ -26,6 +28,7 @@ class SpiderAnimationMod {
     init {
         val bus = FMLJavaModLoadingContext.get().modEventBus
         bus.addListener(this::commonSetup)
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, SpiderConfig.SPEC)
         ModItems.ITEMS.register(bus)
         MinecraftForge.EVENT_BUS.register(this)
     }

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderConfig.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderConfig.kt
@@ -1,0 +1,53 @@
+package com.heledron.spideranimation
+
+import net.minecraftforge.common.ForgeConfigSpec
+import net.minecraftforge.eventbus.api.SubscribeEvent
+import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.config.ModConfig
+import net.minecraftforge.fml.event.config.ModConfigEvent
+
+/**
+ * Forge configuration for the Spider Animation mod.  This replaces the
+ * previous Bukkit based configuration by persisting options in a standard
+ * Forge config file.
+ */
+object SpiderConfig {
+    private val builder = ForgeConfigSpec.Builder()
+
+    val SHOW_LASER: ForgeConfigSpec.BooleanValue =
+        builder.comment("Render laser pointer").define("showLaser", true)
+    val SHOW_DEBUG: ForgeConfigSpec.BooleanValue =
+        builder.comment("Show debug visuals").define("showDebug", false)
+    val GALLOP: ForgeConfigSpec.BooleanValue =
+        builder.comment("Enable gallop gait").define("gallop", false)
+
+    val SPEC: ForgeConfigSpec = builder.build()
+    lateinit var config: ModConfig
+
+    /** Save the config to disk when values are changed at runtime. */
+    fun save() {
+        if (::config.isInitialized) config.save()
+    }
+}
+
+@Mod.EventBusSubscriber(modid = SpiderAnimationMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+object ConfigHandler {
+    @SubscribeEvent
+    fun onLoad(event: ModConfigEvent) {
+        if (event.config.spec != SpiderConfig.SPEC) return
+        SpiderConfig.config = event.config
+        apply()
+    }
+
+    @SubscribeEvent
+    fun onReload(event: ModConfigEvent.Reloading) {
+        if (event.config.spec != SpiderConfig.SPEC) return
+        apply()
+    }
+
+    private fun apply() {
+        AppState.miscOptions.showLaser = SpiderConfig.SHOW_LASER.get()
+        AppState.showDebugVisuals = SpiderConfig.SHOW_DEBUG.get()
+        AppState.gallop = SpiderConfig.GALLOP.get()
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce Forge `ModConfig` to persist debug, gallop, and laser options
- Register config and wire item toggles to update saved values
- Protect spider commands behind Forge permission requirements

## Testing
- `gradle wrapper`
- `./gradlew build` *(fails: Could not resolve org.spigotmc:spigot-api:1.21.3-R0.1-SNAPSHOT; Could not find net.minecraftforge:forge:1.20.1-47.3.0_mapped_official_1.20.1)*

------
https://chatgpt.com/codex/tasks/task_b_6894fd5fcca08329a06337aafac4f6db