### PR TITLE
Remove Spigot dependencies from build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,14 +55,11 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven("https://maven.minecraftforge.net")
-    maven("https://papermc.io/repo/repository/maven-public/")
-    maven("https://oss.sonatype.org/content/groups/public/")
 }
 
 dependencies {
     minecraft("net.minecraftforge:forge:1.20.1-47.3.0")
     implementation(kotlin("stdlib"))
-    compileOnly("org.spigotmc:spigot-api:1.21.3-R0.1-SNAPSHOT")
 }
 
 sourceSets.main.get().resources.srcDir("src/generated/resources")


### PR DESCRIPTION
## Summary
- drop Spigot compile-only dependency
- remove Paper/Spigot repositories from Gradle config

## Testing
- `gradle dependencies --configuration compileClasspath --console=plain` *(fails: Could not resolve all dependencies; Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_b_6895e6eb8fdc8329ad37bfc244577720