### PR TITLE
refactor: remove bukkit dependencies

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/AppState.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/AppState.kt
@@ -4,7 +4,9 @@ import com.heledron.spideranimation.kinematic_chain_visualizer.KinematicChainVis
 import com.heledron.spideranimation.spider.*
 import com.heledron.spideranimation.spider.presets.hexBot
 import com.heledron.spideranimation.utilities.MultiEntityRenderer
-import org.bukkit.Location
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.phys.Vec3
+import org.joml.Quaternionf
 import java.io.Closeable
 
 object AppState {
@@ -24,7 +26,7 @@ object AppState {
         field = value
     }
 
-    var target: Location? = null
+    var target: Vec3? = null
 
     var chainVisualizer: KinematicChainVisualizer? = null
     set (value) {
@@ -32,16 +34,17 @@ object AppState {
         field = value
     }
 
-    fun createSpider(location: Location): Spider {
-        location.y += options.walkGait.stationary.bodyHeight
-        val spider = Spider.fromLocation(location, options)
+    fun createSpider(level: ServerLevel, position: Vec3, orientation: Quaternionf = Quaternionf()): Spider {
+        val adjusted = position.add(0.0, options.walkGait.stationary.bodyHeight, 0.0)
+        val spider = Spider.fromPosition(level, adjusted, orientation, options)
         this.spider = spider
         return spider
     }
 
     fun recreateSpider() {
-        val location = this.spider?.location() ?: return
-        createSpider(location)
+        val spider = this.spider ?: return
+        val level = spider.world as? ServerLevel ?: return
+        createSpider(level, spider.position, spider.orientation)
     }
 }
 


### PR DESCRIPTION
## Summary
- drop Bukkit imports from SpiderAnimationMod and use ServerLevel/Vec3
- migrate AppState to Vec3 positions and ServerLevel world references

## Testing
- `./gradlew --version` *(fails: Unable to access jarfile /workspace/minecraft-spider/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_68964a5f02dc8329b85d157a005b9d00