### PR TITLE
Use BlockState for spider models

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/presets/AnimatedPalettes.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/presets/AnimatedPalettes.kt
@@ -1,43 +1,43 @@
 package com.heledron.spideranimation.spider.presets
 
-import org.bukkit.Material
-import org.bukkit.block.data.BlockData
-import org.bukkit.entity.Display
+import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.level.block.state.BlockState
+import com.heledron.spideranimation.utilities.Brightness
 
-enum class AnimatedPalettes(val palette: List<Pair<BlockData, Display.Brightness>>) {
+enum class AnimatedPalettes(val palette: List<Pair<BlockState, Brightness>>) {
     CYAN_EYES(arrayOf(
-        * Array(3) { Material.CYAN_SHULKER_BOX },
-        Material.CYAN_CONCRETE,
-        Material.CYAN_CONCRETE_POWDER,
+        * Array(3) { Blocks.CYAN_SHULKER_BOX },
+        Blocks.CYAN_CONCRETE,
+        Blocks.CYAN_CONCRETE_POWDER,
 
-        Material.LIGHT_BLUE_SHULKER_BOX,
-        Material.LIGHT_BLUE_CONCRETE,
-        Material.LIGHT_BLUE_CONCRETE_POWDER,
-    ).map { it.createBlockData() to Display.Brightness(15,15) }),
+        Blocks.LIGHT_BLUE_SHULKER_BOX,
+        Blocks.LIGHT_BLUE_CONCRETE,
+        Blocks.LIGHT_BLUE_CONCRETE_POWDER,
+    ).map { it.defaultBlockState() to Brightness(15,15) }),
 
     CYAN_BLINKING_LIGHTS(arrayOf(
-        * Array(3) { Material.BLACK_SHULKER_BOX to Display.Brightness(0,15) },
-        * Array(3) { Material.VERDANT_FROGLIGHT to Display.Brightness(15,15) },
-        Material.LIGHT_BLUE_SHULKER_BOX to Display.Brightness(15,15),
-        Material.LIGHT_BLUE_CONCRETE to Display.Brightness(15,15),
-        Material.LIGHT_BLUE_CONCRETE_POWDER to Display.Brightness(15,15),
-    ).map { (block, brightness) -> block.createBlockData() to brightness }),
+        * Array(3) { Blocks.BLACK_SHULKER_BOX to Brightness(0,15) },
+        * Array(3) { Blocks.VERDANT_FROGLIGHT to Brightness(15,15) },
+        Blocks.LIGHT_BLUE_SHULKER_BOX to Brightness(15,15),
+        Blocks.LIGHT_BLUE_CONCRETE to Brightness(15,15),
+        Blocks.LIGHT_BLUE_CONCRETE_POWDER to Brightness(15,15),
+    ).map { (block, brightness) -> block.defaultBlockState() to brightness }),
 
 
     RED_EYES(arrayOf(
-        * Array(3) { Material.RED_SHULKER_BOX },
-        Material.RED_CONCRETE,
-        Material.RED_CONCRETE_POWDER,
+        * Array(3) { Blocks.RED_SHULKER_BOX },
+        Blocks.RED_CONCRETE,
+        Blocks.RED_CONCRETE_POWDER,
 
-        Material.FIRE_CORAL_BLOCK,
-        Material.REDSTONE_BLOCK,
-    ).map { it.createBlockData() to Display.Brightness(15,15) }),
+        Blocks.FIRE_CORAL_BLOCK,
+        Blocks.REDSTONE_BLOCK,
+    ).map { it.defaultBlockState() to Brightness(15,15) }),
 
     RED_BLINKING_LIGHTS(arrayOf(
-        * Array(3) { Material.BLACK_SHULKER_BOX to Display.Brightness(0,15) },
-        * Array(3) { Material.PEARLESCENT_FROGLIGHT to Display.Brightness(15,15) },
-        Material.RED_TERRACOTTA to Display.Brightness(15,15),
-        Material.REDSTONE_BLOCK to Display.Brightness(15,15),
-        Material.FIRE_CORAL_BLOCK to Display.Brightness(15,15),
-    ).map { (block, brightness) -> block.createBlockData() to brightness }),
+        * Array(3) { Blocks.BLACK_SHULKER_BOX to Brightness(0,15) },
+        * Array(3) { Blocks.PEARLESCENT_FROGLIGHT to Brightness(15,15) },
+        Blocks.RED_TERRACOTTA to Brightness(15,15),
+        Blocks.REDSTONE_BLOCK to Brightness(15,15),
+        Blocks.FIRE_CORAL_BLOCK to Brightness(15,15),
+    ).map { (block, brightness) -> block.defaultBlockState() to brightness }),
 }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/presets/SpiderLegModels.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/presets/SpiderLegModels.kt
@@ -1,7 +1,7 @@
 package com.heledron.spideranimation.spider.presets
 
 import com.heledron.spideranimation.utilities.parseModelFromCommand
-import org.bukkit.Material
+import net.minecraft.world.level.block.Blocks
 
 object SpiderLegModel {
     val BASE = parseModelFromCommand(
@@ -28,8 +28,8 @@ object SpiderLegModel {
         pieces.forEach {
             it.tags += "tibia"
             it.tags += "leg"
-            if (it.block.material == Material.SMOOTH_QUARTZ) it.tags += "cloak"
-            if (it.tags.contains("cloak")) it.block = Material.WHITE_CONCRETE.createBlockData()
+            if (it.block.is(Blocks.SMOOTH_QUARTZ)) it.tags += "cloak"
+            if (it.tags.contains("cloak")) it.block = Blocks.WHITE_CONCRETE.defaultBlockState()
         }
     }
 
@@ -39,8 +39,8 @@ object SpiderLegModel {
         pieces.forEach {
             it.tags += "tip"
             it.tags += "leg"
-            if (it.block.material == Material.SMOOTH_QUARTZ) it.tags += "cloak"
-            if (it.tags.contains("cloak")) it.block = Material.WHITE_CONCRETE.createBlockData()
+            if (it.block.is(Blocks.SMOOTH_QUARTZ)) it.tags += "cloak"
+            if (it.tags.contains("cloak")) it.block = Blocks.WHITE_CONCRETE.defaultBlockState()
         }
     }
 }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/presets/SpiderTorsoModels.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/presets/SpiderTorsoModels.kt
@@ -2,7 +2,7 @@ package com.heledron.spideranimation.spider.presets
 
 import com.heledron.spideranimation.utilities.DisplayModel
 import com.heledron.spideranimation.utilities.parseModelFromCommand
-import org.bukkit.Material
+import net.minecraft.world.level.block.Blocks
 
 enum class SpiderTorsoModels(val model: DisplayModel) {
     EMPTY(DisplayModel.empty()),
@@ -14,8 +14,8 @@ enum class SpiderTorsoModels(val model: DisplayModel) {
         scale(.8f)
         pieces.forEach {
             it.tags += "torso"
-            if (it.block.material == Material.SMOOTH_QUARTZ) it.tags += "cloak"
-            if (it.tags.contains("cloak")) it.block = org.bukkit.Material.WHITE_CONCRETE.createBlockData()
+            if (it.block.is(Blocks.SMOOTH_QUARTZ)) it.tags += "cloak"
+            if (it.tags.contains("cloak")) it.block = Blocks.WHITE_CONCRETE.defaultBlockState()
         }
     }),
 
@@ -26,8 +26,8 @@ enum class SpiderTorsoModels(val model: DisplayModel) {
         scale(.75f)
         pieces.forEach {
             it.tags += "torso"
-            if (it.block.material == Material.SMOOTH_QUARTZ) it.tags += "cloak"
-            if (it.tags.contains("cloak")) it.block = org.bukkit.Material.WHITE_CONCRETE.createBlockData()
+            if (it.block.is(Blocks.SMOOTH_QUARTZ)) it.tags += "cloak"
+            if (it.tags.contains("cloak")) it.block = Blocks.WHITE_CONCRETE.defaultBlockState()
         }
     }),
 
@@ -38,8 +38,8 @@ enum class SpiderTorsoModels(val model: DisplayModel) {
         this.scale(.8f)
         this.pieces.forEach {
             it.tags += "torso"
-            if (it.block.material == Material.BLACK_CONCRETE) it.tags += "cloak"
-            if (it.block.material == Material.BLACK_CONCRETE) it.block = org.bukkit.Material.WHITE_CONCRETE.createBlockData()
+            if (it.block.is(Blocks.BLACK_CONCRETE)) it.tags += "cloak"
+            if (it.block.is(Blocks.BLACK_CONCRETE)) it.block = Blocks.WHITE_CONCRETE.defaultBlockState()
         }
     }),
 }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/presets/applyLegModels.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/presets/applyLegModels.kt
@@ -3,18 +3,18 @@ package com.heledron.spideranimation.spider.presets
 import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.spider.configuration.BodyPlan
 import com.heledron.spideranimation.utilities.BlockDisplayModelPiece
+import com.heledron.spideranimation.utilities.Brightness
 import com.heledron.spideranimation.utilities.DisplayModel
-import org.bukkit.block.data.BlockData
-import org.bukkit.entity.Display
+import net.minecraft.world.level.block.state.BlockState
 import org.joml.Matrix4f
 
 
-private fun createDefaultModel(block: BlockData, length: Double, thickness: Double) = DisplayModel(listOf(BlockDisplayModelPiece(
+private fun createDefaultModel(block: BlockState, length: Double, thickness: Double) = DisplayModel(listOf(BlockDisplayModelPiece(
     block = block,
     transform = Matrix4f()
         .scale(thickness.toFloat(), thickness.toFloat(), length.toFloat())
         .translate(-.5f,-.5f,.0f),
-    brightness = Display.Brightness(0, 15),
+    brightness = Brightness(0, 15),
     tags = listOf("cloak")
 )))
 
@@ -26,7 +26,7 @@ fun applyEmptyLegModel(bodyPlan: BodyPlan) {
     }
 }
 
-fun applyLineLegModel(bodyPlan: BodyPlan, block: BlockData) {
+fun applyLineLegModel(bodyPlan: BodyPlan, block: BlockState) {
     val rootThickness = 1.0/16 * 4.5
     val tipThickness = 1.0/16 * 1.5
 

--- a/src/main/kotlin/com/heledron/spideranimation/spider/presets/presets.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/presets/presets.kt
@@ -5,7 +5,7 @@ import com.heledron.spideranimation.spider.configuration.LegPlan
 import com.heledron.spideranimation.spider.configuration.SegmentPlan
 import com.heledron.spideranimation.spider.configuration.SpiderOptions
 import com.heledron.spideranimation.utilities.FORWARD_VECTOR
-import org.bukkit.Material
+import net.minecraft.world.level.block.Blocks
 import org.bukkit.util.Vector
 
 
@@ -21,7 +21,7 @@ private fun BodyPlan.addLegPair(root: Vector, rest: Vector, segments: List<Segme
 fun biped(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
     options.bodyPlan.addLegPair(Vector(.0, .0, .0), Vector(1.0, .0, .0), equalLength(segmentCount, 1.0 * segmentLength))
-    applyLineLegModel(options.bodyPlan, Material.NETHERITE_BLOCK.createBlockData())
+      applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 
@@ -29,7 +29,7 @@ fun quadruped(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
     options.bodyPlan.addLegPair(Vector(.0, .0, .0), Vector(0.9,.0, 0.9), equalLength(segmentCount, 0.9 * segmentLength))
     options.bodyPlan.addLegPair(Vector(.0, .0, .0), Vector(1.0, .0, -1.1), equalLength(segmentCount, 1.2 * segmentLength))
-    applyLineLegModel(options.bodyPlan, Material.NETHERITE_BLOCK.createBlockData())
+      applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 
@@ -38,7 +38,7 @@ fun hexapod(segmentCount: Int, segmentLength: Double): SpiderOptions {
     options.bodyPlan.addLegPair(Vector(.0,.0,0.1), Vector(1.0,.0, 1.1), equalLength(segmentCount, 1.1 * segmentLength))
     options.bodyPlan.addLegPair(Vector(.0,.0,0.0), Vector(1.3,.0,-0.3), equalLength(segmentCount, 1.1 * segmentLength))
     options.bodyPlan.addLegPair(Vector(.0,.0,-.1), Vector(1.2,.0,-2.0), equalLength(segmentCount, 1.6 * segmentLength))
-    applyLineLegModel(options.bodyPlan, Material.NETHERITE_BLOCK.createBlockData())
+      applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 
@@ -48,7 +48,7 @@ fun octopod(segmentCount: Int, segmentLength: Double): SpiderOptions {
     options.bodyPlan.addLegPair(Vector(.0,.0,  .0), Vector(1.3, .0,  0.4), equalLength(segmentCount, 1.0 * segmentLength))
     options.bodyPlan.addLegPair(Vector(.0,.0, -.1), Vector(1.3, .0, -0.9), equalLength(segmentCount, 1.1 * segmentLength))
     options.bodyPlan.addLegPair(Vector(.0,.0, -.2), Vector(1.1, .0, -2.5), equalLength(segmentCount, 1.6 * segmentLength))
-    applyLineLegModel(options.bodyPlan, Material.NETHERITE_BLOCK.createBlockData())
+      applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 

--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
@@ -2,8 +2,9 @@ package com.heledron.spideranimation.spider.rendering
 
 import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.utilities.*
-import org.bukkit.*
-import org.bukkit.entity.Display
+import com.heledron.spideranimation.utilities.Brightness
+import net.minecraft.world.level.block.Blocks
+import org.bukkit.Location
 import org.bukkit.util.Vector
 import org.joml.Matrix4f
 import org.joml.Vector4f
@@ -13,9 +14,9 @@ fun targetRenderEntity(
 ) = blockRenderEntity(
     location = location,
     init = {
-        it.block = Material.REDSTONE_BLOCK.createBlockData()
+        it.blockState = Blocks.REDSTONE_BLOCK.defaultBlockState()
         it.teleportDuration = 1
-        it.brightness = Display.Brightness(15, 15)
+        it.setBrightness(Brightness(15, 15))
         it.transformation = centredTransform(.25f, .25f, .25f)
     }
 )
@@ -88,11 +89,11 @@ private fun modelPieceToRenderEntity(
         } else null
 
         if (cloak != null) {
-            it.block = cloak.first
-            it.brightness = cloak.second
+            it.blockState = cloak.first
+            it.setBrightness(cloak.second)
         } else {
-            it.block = piece.block
-            it.brightness = piece.brightness
+            it.blockState = piece.block
+            it.setBrightness(piece.brightness)
         }
     }
 )

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/DisplayModel.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/DisplayModel.kt
@@ -1,13 +1,14 @@
 package com.heledron.spideranimation.utilities
 
-import org.bukkit.block.data.BlockData
-import org.bukkit.entity.Display
+import net.minecraft.world.level.block.state.BlockState
 import org.joml.Matrix4f
 
+data class Brightness(val block: Int, val sky: Int)
+
 class BlockDisplayModelPiece (
-    var block: BlockData,
+    var block: BlockState,
     var transform: Matrix4f,
-    var brightness: Display.Brightness? = null,
+    var brightness: Brightness? = null,
     var tags: List<String> = emptyList(),
 ) {
     fun scale(scale: Float) {
@@ -19,9 +20,9 @@ class BlockDisplayModelPiece (
     }
 
     fun clone() = BlockDisplayModelPiece(
-        block = block.clone(),
+        block = block,
         transform = Matrix4f(transform),
-        brightness = brightness?.let { Display.Brightness(it.blockLight, it.skyLight) },
+        brightness = brightness?.let { Brightness(it.block, it.sky) },
         tags = tags,
     )
 }

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/parseModelFromCommand.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/parseModelFromCommand.kt
@@ -1,43 +1,13 @@
 package com.heledron.spideranimation.utilities
 
 import com.google.gson.Gson
-import org.bukkit.Bukkit
-import org.bukkit.Location
-import org.bukkit.Material
-import org.bukkit.entity.BlockDisplay
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.resources.ResourceLocation
+import net.minecraft.world.level.block.state.BlockState
+import net.minecraft.world.level.block.state.properties.Property
 import org.joml.Matrix4f
 
-fun parseModelWithCommandDispatch(command: String): DisplayModel {
-    val world = Bukkit.getWorlds().first()
-    val location = Location(world, .0,.0,.0)
-
-    runCommandSilently(
-        location = location,
-        command = "execute positioned ${location.x + .5} ${location.y} ${location.z + .5} run ${command.trimStart('/')}"
-    )
-
-    val pieces = mutableListOf<BlockDisplayModelPiece>()
-
-    val radius = 0.001
-    for (entity in world.getNearbyEntities(location, radius, radius, radius)) {
-        if (entity !is BlockDisplay) continue
-
-        val transform = matrixFromTransform(entity.transformation)
-        pieces += BlockDisplayModelPiece(
-            block = entity.block,
-            transform = transform,
-            brightness = entity.brightness,
-            tags = entity.scoreboardTags.toList()
-        )
-
-        entity.remove()
-    }
-
-    return DisplayModel(pieces)
-}
-
 fun parseModelFromCommand(command: String): DisplayModel {
-//    return parseModelWithCommandDispatch(command)
     //summon block_display ~-0.5 ~ ~-0.5 {Passengers:[{id:"minecraft:block_display",block_state:{Name:"minecraft:smooth_quartz",Properties:{}},transformation:[0.1f,0f,0f,0.15f,0f,0.0427f,0.0288f,0.4922f,0f,-0.0022f,0.5492f,-0.8771f,0f,0f,0f,1f]}...
 
     val pieces = mutableListOf<BlockDisplayModelPiece>()
@@ -54,10 +24,16 @@ fun parseModelFromCommand(command: String): DisplayModel {
         val blockDisplay = passenger["block_state"] as? Map<*, *> ?: throw IllegalArgumentException("Missing block_state")
         val blockName = blockDisplay["Name"] as? String ?: throw IllegalArgumentException("Missing block_state.Name")
         val blockProperties = blockDisplay["Properties"] as Map<*, *>
-        val blockData = Material.matchMaterial(blockName)?.createBlockData() ?: throw IllegalArgumentException("Unknown block name: $blockName")
-        if (blockProperties.contains("facing")) {
-            val directional = blockData as? org.bukkit.block.data.Directional ?: throw IllegalArgumentException("Block is not directional")
-            directional.facing = org.bukkit.block.BlockFace.valueOf((blockProperties["facing"] as String).uppercase())
+        val block = BuiltInRegistries.BLOCK.get(ResourceLocation(blockName))
+            ?: throw IllegalArgumentException("Unknown block name: $blockName")
+        var blockData: BlockState = block.defaultBlockState()
+        for ((propName, propValue) in blockProperties) {
+            val property = block.stateDefinition.getProperty(propName as String) ?: continue
+            val parsed = property.getValue(propValue as String)
+            if (parsed.isPresent) {
+                @Suppress("UNCHECKED_CAST")
+                blockData = blockData.setValue(property as Property<Comparable<Any>>, parsed.get() as Comparable<Any>)
+            }
         }
 
         val transformation = passenger["transformation"] as? List<Float> ?: throw IllegalArgumentException("Missing transformation")

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/utilities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/utilities.kt
@@ -6,6 +6,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent
 import net.minecraftforge.fml.common.Mod
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
+import com.heledron.spideranimation.utilities.Brightness
 import net.minecraft.world.level.ClipContext
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.BlockHitResult
@@ -167,5 +168,15 @@ fun net.minecraft.world.entity.Display.applyTransformationWithInterpolation(matr
     val oldTransform = this.transformation
     this.transformation = net.minecraft.util.Mth.quatFromXYZ(0f,0f,0f) // placeholder
     if (oldTransform == this.transformation) return
-    this.interpolationDelay = 0
+      this.interpolationDelay = 0
+      }
+
+fun net.minecraft.world.entity.Display.setBrightness(brightness: Brightness?) {
+    if (brightness == null) {
+        this.setBlockLightLevel(0)
+        this.setSkyLightLevel(0)
+    } else {
+        this.setBlockLightLevel(brightness.block)
+        this.setSkyLightLevel(brightness.sky)
+    }
 }


### PR DESCRIPTION
## Summary
- store BlockState and custom Brightness in DisplayModel pieces
- swap preset material constants for Blocks default states
- render entities and leg models now operate on BlockState

## Testing
- `./gradlew test` *(fails: Unable to access jarfile /workspace/minecraft-spider/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_6899547adfb4832984e9ca9b8928edbf