### PR TITLE
Use vanilla display entities for rendering

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
@@ -3,19 +3,23 @@ package com.heledron.spideranimation.spider.rendering
 import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.utilities.*
 import com.heledron.spideranimation.utilities.Brightness
+import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Blocks
-import org.bukkit.Location
+import net.minecraft.world.phys.Vec3
 import org.bukkit.util.Vector
 import org.joml.Matrix4f
 import org.joml.Vector4f
 
 fun targetRenderEntity(
-    location: Location
+    level: Level,
+    position: Vec3,
 ) = blockRenderEntity(
-    location = location,
+    level = level,
+    position = position,
     init = {
         it.blockState = Blocks.REDSTONE_BLOCK.defaultBlockState()
-        it.teleportDuration = 1
+        it.setTeleportDuration(1)
+        it.setInterpolationDuration(1)
         it.setBrightness(Brightness(15, 15))
         it.transformation = centredTransform(.25f, .25f, .25f)
     }
@@ -67,12 +71,12 @@ private fun modelPieceToRenderEntity(
     position: Vector,
     piece: BlockDisplayModelPiece,
     transformation: Matrix4f,
-//    cloakID: Any
 ) = blockRenderEntity(
-    location = position.toLocation(spider.world),
+    level = spider.world,
+    position = position.toVec3(),
     init = {
-        it.teleportDuration = 1
-        it.interpolationDuration = 1
+        it.setTeleportDuration(1)
+        it.setInterpolationDuration(1)
     },
     update = {
         val transform = Matrix4f(transformation).mul(piece.transform)

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/maths.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/maths.kt
@@ -2,6 +2,7 @@ package com.heledron.spideranimation.utilities
 
 import net.minecraft.world.phys.Vec3
 import org.joml.*
+import org.bukkit.util.Vector
 import java.lang.Math
 import kotlin.math.abs
 import kotlin.math.atan2
@@ -58,6 +59,8 @@ fun Vec3.toVector3f(): Vector3f = Vector3f(this.x.toFloat(), this.y.toFloat(), t
 fun Vector3f.toVec3(): Vec3 = Vec3(this.x.toDouble(), this.y.toDouble(), this.z.toDouble())
 
 fun Vector3d.toVec3(): Vec3 = Vec3(this.x, this.y, this.z)
+
+fun Vector.toVec3(): Vec3 = Vec3(this.x, this.y, this.z)
 
 fun Vec3.rotateAroundY(angle: Double, origin: Vec3): Vec3 {
     val translated = this.subtract(origin)

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/utilities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/utilities.kt
@@ -158,25 +158,14 @@ fun matrixFromTransform(transformation: org.joml.Transformation): Matrix4f {
     return matrix
 }
 
-fun net.minecraft.world.entity.Display.applyTransformationWithInterpolation(transformation: org.joml.Transformation) {
+fun net.minecraft.world.entity.Display.applyTransformationWithInterpolation(matrix: Matrix4f) {
+    val transformation = com.mojang.math.Transformation(matrix)
     if (this.transformation == transformation) return
     this.transformation = transformation
-    this.interpolationDelay = 0
+    this.interpolationStartDelta = 0
 }
 
-fun net.minecraft.world.entity.Display.applyTransformationWithInterpolation(matrix: Matrix4f) {
-    val oldTransform = this.transformation
-    this.transformation = net.minecraft.util.Mth.quatFromXYZ(0f,0f,0f) // placeholder
-    if (oldTransform == this.transformation) return
-      this.interpolationDelay = 0
-      }
-
 fun net.minecraft.world.entity.Display.setBrightness(brightness: Brightness?) {
-    if (brightness == null) {
-        this.setBlockLightLevel(0)
-        this.setSkyLightLevel(0)
-    } else {
-        this.setBlockLightLevel(brightness.block)
-        this.setSkyLightLevel(brightness.sky)
-    }
+    val value = brightness?.let { net.minecraft.world.entity.Display.Brightness(it.block, it.sky) }
+    this.brightnessOverride = value
 }


### PR DESCRIPTION
## Summary
- Replace Bukkit display entities with net.minecraft Display, BlockDisplay and TextDisplay
- Spawn and update entities through Level.addFreshEntity and vanilla transformation data
- Build spider render groups with new renderer and BlockState-based cloak/brightness

## Testing
- `gradle --console=plain test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_b_68995bcf91d483298bfdebb752caee09