### PR TITLE
Use Vec3-based math and server players

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/Cloak.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/Cloak.kt
@@ -11,6 +11,7 @@ import org.bukkit.block.data.BlockData
 import org.bukkit.entity.Display
 import org.bukkit.util.RayTraceResult
 import org.bukkit.util.Vector
+import net.minecraft.server.level.ServerPlayer
 import java.util.WeakHashMap
 
 class Cloak(var  spider: Spider) : SpiderComponent {
@@ -65,9 +66,10 @@ class Cloak(var  spider: Spider) : SpiderComponent {
         }
 
         fun cast(): RayTraceResult? {
-            val targetPlayer = Bukkit.getOnlinePlayers().firstOrNull() ?: return groundCast()
+            val targetPlayer = spider.world.players.firstOrNull() as? ServerPlayer ?: return groundCast()
 
-            val direction = location.toVector().subtract(targetPlayer.eyeLocation.toVector())
+            val eye = targetPlayer.eyePosition
+            val direction = location.toVector().subtract(Vector(eye.x, eye.y, eye.z))
             val rayCast = raycastGround(location, direction, 30.0)
             return rayCast
         }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/PointDetector.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/PointDetector.kt
@@ -4,25 +4,25 @@ import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.spider.SpiderComponent
 import com.heledron.spideranimation.spider.body.Leg
 import com.heledron.spideranimation.utilities.lookingAtPoint
-import org.bukkit.Location
-import org.bukkit.entity.Player
+import com.heledron.spideranimation.utilities.toVec3
+import net.minecraft.server.level.ServerPlayer
 
 class PointDetector(val spider: Spider) : SpiderComponent {
     var selectedLeg: Leg? = null
-    var player: Player? = null
+    var player: ServerPlayer? = null
 
     override fun update() {
         val player = player
-        selectedLeg = if (player !== null) getLeg(player.eyeLocation) else null
+        selectedLeg = if (player != null) getLeg(player) else null
     }
 
-    private fun getLeg(location: Location): Leg? {
-        if (spider.world != location.world) return null
+    private fun getLeg(player: ServerPlayer): Leg? {
+        if (spider.world != player.level()) return null
 
-        val locationAsVector = location.toVector()
-        val direction = location.direction
+        val eye = player.eyePosition
+        val direction = player.lookAngle
         for (leg in spider.body.legs) {
-            val lookingAt = lookingAtPoint(locationAsVector, direction, leg.endEffector, spider.lerpedGait.bodyHeight * .15)
+            val lookingAt = lookingAtPoint(eye, direction, leg.endEffector.toVec3(), spider.lerpedGait.bodyHeight * .15)
             if (lookingAt) return leg
         }
         return null

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/maths.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/maths.kt
@@ -62,6 +62,8 @@ fun Vector3d.toVec3(): Vec3 = Vec3(this.x, this.y, this.z)
 
 fun Vector.toVec3(): Vec3 = Vec3(this.x, this.y, this.z)
 
+fun Vec3.toVector(): Vector = Vector(this.x, this.y, this.z)
+
 fun Vec3.rotateAroundY(angle: Double, origin: Vec3): Vec3 {
     val translated = this.subtract(origin)
     val sin = kotlin.math.sin(angle)


### PR DESCRIPTION
## Summary
- Replace Bukkit vectors and players with `Vec3` and `ServerPlayer` in point detection and items
- Rework trident hit detector to query `ThrownTrident` entities and apply knockback with Forge physics
- Add vector conversion helper and update cloak targeting to use player `eyePosition`

## Testing
- `./gradlew test` *(fails: Unable to access jarfile /workspace/minecraft-spider/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_689a4b18f6b08329af4048f0473d0f0e