### PR TITLE
Port sound/particle calls to SoundEvents and ParticleOptions

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -10,10 +10,11 @@ import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.Level
+import net.minecraft.world.phys.Vec3
+import net.minecraft.sounds.SoundEvents
 import net.minecraftforge.registries.DeferredRegister
 import net.minecraftforge.registries.ForgeRegistries
 import net.minecraftforge.registries.RegistryObject
-import org.bukkit.Sound
 import org.bukkit.entity.Player as BukkitPlayer
 import kotlin.math.roundToInt
 
@@ -48,11 +49,11 @@ class SpiderItem(properties: Properties) : Item(properties) {
             val hit = raycastGround(playerLocation, playerLocation.direction, 100.0)?.hitPosition
                 ?.toLocation(playerLocation.world!!) ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
             hit.yaw = yawRounded
-            playSound(hit, Sound.BLOCK_NETHERITE_BLOCK_PLACE, 1.0f, 1.0f)
+            playSound(level, Vec3(hit.x, hit.y, hit.z), SoundEvents.NETHERITE_BLOCK_PLACE, 1.0f, 1.0f)
             AppState.createSpider(hit)
             sendActionBar(bukkitPlayer, "Spider created")
         } else {
-            playSound(bukkitPlayer.location, Sound.ENTITY_ITEM_FRAME_REMOVE_ITEM, 1.0f, 0.0f)
+            playSound(level, player.position(), SoundEvents.ITEM_FRAME_REMOVE_ITEM, 1.0f, 0.0f)
             AppState.spider = null
             sendActionBar(bukkitPlayer, "Spider removed")
         }
@@ -73,11 +74,11 @@ class DisableLegItem(properties: Properties) : Item(properties) {
         val bukkitPlayer = toBukkit(player)
         val selectedLeg = AppState.spider?.pointDetector?.selectedLeg
         if (selectedLeg == null) {
-            playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, 2.0f)
+            playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
             return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
         }
         selectedLeg.isDisabled = !selectedLeg.isDisabled
-        playSound(bukkitPlayer.location, Sound.BLOCK_LANTERN_PLACE, 1.0f, 1.0f)
+        playSound(level, player.position(), SoundEvents.LANTERN_PLACE, 1.0f, 1.0f)
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }
@@ -91,7 +92,7 @@ class ToggleDebugItem(properties: Properties) : Item(properties) {
         SpiderConfig.save()
         AppState.chainVisualizer?.detailed = AppState.showDebugVisuals
         val pitch = if (AppState.showDebugVisuals) 2.0f else 1.5f
-        playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, pitch)
+        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, pitch)
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }
@@ -102,10 +103,10 @@ class SwitchRendererItem(properties: Properties) : Item(properties) {
         val bukkitPlayer = toBukkit(player)
         val spider = AppState.spider ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
         spider.renderer = if (spider.renderer is SpiderRenderer) {
-            playSound(bukkitPlayer.location, Sound.ENTITY_AXOLOTL_ATTACK, 1.0f, 1.0f)
+            playSound(level, player.position(), SoundEvents.AXOLOTL_ATTACK, 1.0f, 1.0f)
             SpiderParticleRenderer(spider)
         } else {
-            playSound(bukkitPlayer.location, Sound.ITEM_ARMOR_EQUIP_NETHERITE, 1.0f, 1.0f)
+            playSound(level, player.position(), SoundEvents.ARMOR_EQUIP_NETHERITE, 1.0f, 1.0f)
             SpiderRenderer(spider)
         }
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
@@ -126,7 +127,7 @@ class ChainVisStepItem(properties: Properties) : Item(properties) {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
         val bukkitPlayer = toBukkit(player)
         val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, 2.0f)
+        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
         chain.step()
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
@@ -137,7 +138,7 @@ class ChainVisStraightenItem(properties: Properties) : Item(properties) {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
         val bukkitPlayer = toBukkit(player)
         val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, 2.0f)
+        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
         chain.straighten(chain.target?.toVector() ?: return InteractionResultHolder.pass(player.getItemInHand(hand)))
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
@@ -147,7 +148,7 @@ class SwitchGaitItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
         val bukkitPlayer = toBukkit(player)
-        playSound(bukkitPlayer.location, Sound.BLOCK_DISPENSER_FAIL, 1.0f, 2.0f)
+        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
         AppState.gallop = !AppState.gallop
         SpiderConfig.GALLOP.set(AppState.gallop)
         SpiderConfig.save()

--- a/src/main/kotlin/com/heledron/spideranimation/spider/configuration/SpiderOptions.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/configuration/SpiderOptions.kt
@@ -1,8 +1,10 @@
 package com.heledron.spideranimation.spider.configuration
 
 import com.heledron.spideranimation.utilities.playSound
-import org.bukkit.Sound
-import org.bukkit.util.Vector
+import net.minecraft.sounds.SoundEvent
+import net.minecraft.sounds.SoundEvents
+import net.minecraft.world.level.Level
+import net.minecraft.world.phys.Vec3
 import kotlin.random.Random
 
 class SpiderOptions {
@@ -27,7 +29,7 @@ class SpiderOptions {
 
 class SoundOptions {
     var step = SoundPlayer(
-        sound = Sound.BLOCK_NETHERITE_BLOCK_STEP,
+        sound = SoundEvents.NETHERITE_BLOCK_STEP,
         volume = .3f,
         pitch = 1.0f
     )
@@ -35,15 +37,15 @@ class SoundOptions {
 
 
 class SoundPlayer(
-    val sound: Sound,
+    val sound: SoundEvent,
     val volume: Float,
     val pitch: Float,
     val volumeVary: Float = 0.1f,
     val pitchVary: Float = 0.1f
 ) {
-    fun play(world: org.bukkit.World, position: Vector) {
+    fun play(level: Level, position: Vec3) {
         val volume = volume + Random.nextFloat() * volumeVary
         val pitch = pitch + Random.nextFloat() * pitchVary
-        world.playSound(position, sound, volume, pitch)
+        playSound(level, position, sound, volume, pitch)
     }
 }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/SoundsAndParticles.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/SoundsAndParticles.kt
@@ -5,9 +5,13 @@ import com.heledron.spideranimation.spider.SpiderComponent
 import com.heledron.spideranimation.spider.body.Leg
 import com.heledron.spideranimation.spider.configuration.SoundPlayer
 import com.heledron.spideranimation.utilities.playSound
-import org.bukkit.Particle
-import org.bukkit.Sound
-import org.bukkit.block.data.Waterlogged
+import com.heledron.spideranimation.utilities.spawnParticle
+import com.heledron.spideranimation.utilities.toVec3
+import net.minecraft.core.BlockPos
+import net.minecraft.core.particles.ParticleTypes
+import net.minecraft.sounds.SoundEvents
+import net.minecraft.world.level.block.state.properties.BlockStateProperties
+import net.minecraft.world.level.material.Fluids
 import org.bukkit.util.Vector
 import java.io.Closeable
 import java.util.*
@@ -31,36 +35,38 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
 
     init {
         closeables += spider.body.onHitGround.listen {
-            spider.world.playSound(spider.position, Sound.BLOCK_NETHERITE_BLOCK_FALL, 1.0f, .8f)
+            playSound(spider.world, spider.position, SoundEvents.NETHERITE_BLOCK_FALL, 1.0f, .8f)
         }
 
         closeables += spider.tridentDetector.onHit.listen {
-            spider.world.playSound(spider.position, Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, .5f, 1.0f)
+            playSound(spider.world, spider.position, SoundEvents.ZOMBIE_ATTACK_IRON_DOOR, .5f, 1.0f)
         }
 
         closeables += spider.cloak.onToggle.listen {
-            spider.world.playSound(spider.position, Sound.BLOCK_LODESTONE_PLACE, 1.0f, 0.0f)
+            playSound(spider.world, spider.position, SoundEvents.LODESTONE_PLACE, 1.0f, 0.0f)
         }
 
         closeables += spider.cloak.onCloakDamage.listen {
-            spider.world.playSound(spider.position, Sound.BLOCK_RESPAWN_ANCHOR_DEPLETE, .5f, 1.5f)
-            spider.world.playSound(spider.position, Sound.BLOCK_LODESTONE_PLACE, 0.1f, 0.0f)
-            spider.world.playSound(spider.position, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, .02f, 1.5f)
+            playSound(spider.world, spider.position, SoundEvents.RESPAWN_ANCHOR_DEPLETE, .5f, 1.5f)
+            playSound(spider.world, spider.position, SoundEvents.LODESTONE_PLACE, 0.1f, 0.0f)
+            playSound(spider.world, spider.position, SoundEvents.ZOMBIE_VILLAGER_CURE, .02f, 1.5f)
         }
 
         for (leg in spider.body.legs) {
             closeables += leg.onStep.listen {
-                val isUnderWater = spider.world.getBlockAt(leg.endEffector.toLocation(spider.world)).isLiquid
+                val isUnderWater = isInWater(leg.endEffector)
                 val sound = if (isUnderWater) underwaterStepSound else spider.options.sound.step
 
-                sound.play(spider.world, leg.endEffector)
+                sound.play(spider.world, leg.endEffector.toVec3())
             }
         }
     }
 
     private fun isInWater(position: Vector): Boolean {
-        val block = spider.world.getBlockAt(position.toLocation(spider.world))
-        return block.isLiquid || (block is Waterlogged && block.isWaterlogged)
+        val blockPos = BlockPos(position.x.toInt(), position.y.toInt(), position.z.toInt())
+        val state = spider.world.getBlockState(blockPos)
+        return state.fluidState.type == Fluids.WATER ||
+                (state.hasProperty(BlockStateProperties.WATERLOGGED) && state.getValue(BlockStateProperties.WATERLOGGED))
     }
 
     var timeSinceLastSound = 0
@@ -84,19 +90,19 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
                 if (justEnteredWater) {
                     val volume = .3f
                     val pitch = 1.0f + Random.nextFloat() * 0.1f
-                    spider.world.playSound(leg.endEffector, Sound.ENTITY_PLAYER_SPLASH, volume, pitch)
+                    playSound(spider.world, leg.endEffector.toVec3(), SoundEvents.PLAYER_SPLASH, volume, pitch)
                     timeSinceLastSound = 0
                 }
                 else if (justExitedWater) {
                     val volume = .3f
                     val pitch = 1f + Random.nextFloat() * 0.1f
-                    spider.world.playSound(leg.endEffector, Sound.AMBIENT_UNDERWATER_EXIT, volume, pitch)
+                    playSound(spider.world, leg.endEffector.toVec3(), SoundEvents.AMBIENT_UNDERWATER_EXIT, volume, pitch)
                     timeSinceLastSound = 0
                 }
                 else if (justBegunMoving && isUnderWater) {
                     val volume = .3f
                     val pitch = .7f + Random.nextFloat() * 0.1f
-                    spider.world.playSound(leg.endEffector, Sound.ENTITY_PLAYER_SWIM, volume, pitch)
+                    playSound(spider.world, leg.endEffector.toVec3(), SoundEvents.PLAYER_SWIM, volume, pitch)
                     timeSinceLastSound = 0
                 }
             }
@@ -107,15 +113,15 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
             for (segment in leg.chain.segments) {
                 val segmentIsUnderWater = isInWater(segment.position)
 
-                val location = segment.position.toLocation(spider.world).add(.0, -.1, .0)
+                val location = segment.position.clone().add(0.0, -0.1, 0.0).toVec3()
 
                 if (segmentIsUnderWater) {
                     if (justEnteredWater || justExitedWater) {
                         val offset = .3
-                        spider.world.spawnParticle(Particle.SPLASH, location, 40, offset, .1, offset)
+                        spawnParticle(spider.world, ParticleTypes.SPLASH, location, 40, offset, .1, offset, 0.0)
                     } else if (leg.isMoving) {
                         val offset = .1
-                        spider.world.spawnParticle(Particle.BUBBLE, location, 1, offset, .0, offset, .0)
+                        spawnParticle(spider.world, ParticleTypes.BUBBLE, location, 1, offset, .0, offset, 0.0)
                     }
                 }
 
@@ -123,7 +129,7 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
                     if (Random.nextInt(0, maxWetness) > wetness) continue
 
                     val offset = .0
-                    spider.world.spawnParticle(Particle.FALLING_WATER, location, 1, offset, offset, offset, .1)
+                    spawnParticle(spider.world, ParticleTypes.FALLING_WATER, location, 1, offset, offset, offset, .1)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Use `SoundEvents` and `SoundEvent` in spider options and utilities
- Spawn particles with `ParticleTypes` and check water via block states
- Play item interaction sounds via `SoundEvent`

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_689a4eb0c76c83299cf8d44cf2a010b4