### PR TITLE
Refactor cloak color mapping to BlockState RGB

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
@@ -89,7 +89,7 @@ private fun modelPieceToRenderEntity(
             piecePosition.y += relative.y
             piecePosition.z += relative.z
 
-            spider.cloak.getPiece(piece, piecePosition, piece.block, piece.brightness)
+            spider.cloak.getPiece(piece, piecePosition.toVec3(), piece.block, piece.brightness)
         } else null
 
         if (cloak != null) {

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/RGB.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/RGB.kt
@@ -1,0 +1,30 @@
+package com.heledron.spideranimation.utilities
+
+import net.minecraft.world.phys.Vec3
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * Simple RGB container used instead of Bukkit's [org.bukkit.Color].
+ */
+data class RGB(val r: Int, val g: Int, val b: Int) {
+    /** Scale the colour to the provided Minecraft brightness level (0-15). */
+    fun withBrightness(brightness: Int): RGB {
+        val factor = brightness.toDouble() / 15.0
+        return RGB((r * factor).toInt(), (g * factor).toInt(), (b * factor).toInt())
+    }
+
+    /** Euclidean distance to another colour. */
+    fun distanceTo(other: RGB): Double {
+        return sqrt(
+            (r - other.r).toDouble().pow(2) +
+            (g - other.g).toDouble().pow(2) +
+            (b - other.b).toDouble().pow(2)
+        )
+    }
+}
+
+fun RGB.toVec3(): Vec3 = Vec3(r.toDouble(), g.toDouble(), b.toDouble())
+
+fun Vec3.toRGB(): RGB = RGB(x.toInt(), y.toInt(), z.toInt())
+


### PR DESCRIPTION
## Summary
- replace Bukkit Color with internal RGB utility and conversions
- read block color data into BlockState mappings and return RGB matches
- update cloak logic to use BlockState + RGB for overrides and transitions

## Testing
- `gradle test` *(fails: Could not resolve all files for configuration ':compileClasspath'. Could not find net.minecraftforge:forge:1.20.1-47.3.0_mapped_official_1.20.1.)*


------
https://chatgpt.com/codex/tasks/task_b_689a516a6fd88329a009a4fc967807f8