### PR TITLE
feat: parse block display models via server context

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/utilities/commands.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/commands.kt
@@ -1,0 +1,22 @@
+package com.heledron.spideranimation.utilities
+
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.entity.Entity
+import net.minecraft.world.phys.Vec3
+
+/** Execute a command without producing chat output. */
+fun runCommandSilently(level: ServerLevel, command: String) {
+    val server = level.server
+    val stack = server.createCommandSourceStack()
+        .withLevel(level)
+        .withPosition(Vec3(0.0, 0.0, 0.0))
+        .withSuppressedOutput()
+    server.commands.performPrefixedCommand(stack, command.removePrefix("/"))
+}
+
+/** Convenience overload that derives the [ServerLevel] from an [Entity]. */
+fun runCommandSilently(entity: Entity, command: String) {
+    val level = entity.level() as? ServerLevel ?: return
+    runCommandSilently(level, command)
+}
+


### PR DESCRIPTION
## Summary
- derive display models by executing summon commands with CommandSourceStack
- add helper to run server commands silently

## Testing
- `gradle build` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_b_689a555ff4e883299515ba6d7d1c58c8