### PR TITLE
Refactor item interactions to native server APIs

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -6,16 +6,18 @@ import com.heledron.spideranimation.spider.rendering.*
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.InteractionResultHolder
 import net.minecraft.world.entity.Entity
+import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.Level
 import net.minecraft.world.phys.Vec3
 import net.minecraft.sounds.SoundEvents
+import net.minecraft.sounds.SoundSource
+import net.minecraft.network.chat.Component
 import net.minecraftforge.registries.DeferredRegister
 import net.minecraftforge.registries.ForgeRegistries
 import net.minecraftforge.registries.RegistryObject
-import org.bukkit.entity.Player as BukkitPlayer
 import kotlin.math.roundToInt
 
 object ModItems {
@@ -33,29 +35,26 @@ object ModItems {
     val COME_HERE: RegistryObject<Item> = ITEMS.register("come_here") { ComeHereItem(Item.Properties()) }
 }
 
-private fun toBukkit(player: ServerPlayer): BukkitPlayer = player.bukkitEntity as BukkitPlayer
-
 class SpiderItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
         val spider = AppState.spider
         if (spider == null) {
             val yawIncrements = 45.0f
-            val yaw = bukkitPlayer.location.yaw
+            val yaw = player.yHeadRot
             val yawRounded = (yaw / yawIncrements).roundToInt() * yawIncrements
             val eye = player.eyePosition
-            val playerLocation = org.bukkit.Location(bukkitPlayer.world, eye.x, eye.y, eye.z, bukkitPlayer.location.yaw, bukkitPlayer.location.pitch)
-            val hit = raycastGround(playerLocation, playerLocation.direction, 100.0)?.hitPosition
-                ?.toLocation(playerLocation.world!!) ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-            hit.yaw = yawRounded
-            playSound(level, Vec3(hit.x, hit.y, hit.z), SoundEvents.NETHERITE_BLOCK_PLACE, 1.0f, 1.0f)
-            AppState.createSpider(hit)
-            sendActionBar(bukkitPlayer, "Spider created")
+            val result = level.raycastGround(eye, player.lookAngle, 100.0)
+                ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
+            val hit = result.location
+            val orientation = org.joml.Quaternionf().rotateY(Math.toRadians(yawRounded.toDouble()).toFloat())
+            level.playSound(null, hit.x, hit.y, hit.z, SoundEvents.NETHERITE_BLOCK_PLACE, SoundSource.BLOCKS, 1.0f, 1.0f)
+            AppState.createSpider(level as ServerLevel, hit, orientation)
+            player.displayClientMessage(Component.literal("Spider created"), true)
         } else {
-            playSound(level, player.position(), SoundEvents.ITEM_FRAME_REMOVE_ITEM, 1.0f, 0.0f)
+            level.playSound(null, player.x, player.y, player.z, SoundEvents.ITEM_FRAME_REMOVE_ITEM, SoundSource.BLOCKS, 1.0f, 0.0f)
             AppState.spider = null
-            sendActionBar(bukkitPlayer, "Spider removed")
+            player.displayClientMessage(Component.literal("Spider removed"), true)
         }
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
@@ -71,14 +70,13 @@ class DisableLegItem(properties: Properties) : Item(properties) {
 
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
         val selectedLeg = AppState.spider?.pointDetector?.selectedLeg
         if (selectedLeg == null) {
-            playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
+            level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
             return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
         }
         selectedLeg.isDisabled = !selectedLeg.isDisabled
-        playSound(level, player.position(), SoundEvents.LANTERN_PLACE, 1.0f, 1.0f)
+        level.playSound(null, player.x, player.y, player.z, SoundEvents.LANTERN_PLACE, SoundSource.BLOCKS, 1.0f, 1.0f)
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }
@@ -86,13 +84,12 @@ class DisableLegItem(properties: Properties) : Item(properties) {
 class ToggleDebugItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
         AppState.showDebugVisuals = !AppState.showDebugVisuals
         SpiderConfig.SHOW_DEBUG.set(AppState.showDebugVisuals)
         SpiderConfig.save()
         AppState.chainVisualizer?.detailed = AppState.showDebugVisuals
         val pitch = if (AppState.showDebugVisuals) 2.0f else 1.5f
-        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, pitch)
+        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, pitch)
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }
@@ -100,13 +97,12 @@ class ToggleDebugItem(properties: Properties) : Item(properties) {
 class SwitchRendererItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
         val spider = AppState.spider ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
         spider.renderer = if (spider.renderer is SpiderRenderer) {
-            playSound(level, player.position(), SoundEvents.AXOLOTL_ATTACK, 1.0f, 1.0f)
+            level.playSound(null, player.x, player.y, player.z, SoundEvents.AXOLOTL_ATTACK, SoundSource.BLOCKS, 1.0f, 1.0f)
             SpiderParticleRenderer(spider)
         } else {
-            playSound(level, player.position(), SoundEvents.ARMOR_EQUIP_NETHERITE, 1.0f, 1.0f)
+            level.playSound(null, player.x, player.y, player.z, SoundEvents.ARMOR_EQUIP_NETHERITE, SoundSource.BLOCKS, 1.0f, 1.0f)
             SpiderRenderer(spider)
         }
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
@@ -125,9 +121,8 @@ class ToggleCloakItem(properties: Properties) : Item(properties) {
 class ChainVisStepItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
         val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
+        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
         chain.step()
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
@@ -136,9 +131,8 @@ class ChainVisStepItem(properties: Properties) : Item(properties) {
 class ChainVisStraightenItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
         val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
+        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
         chain.straighten(chain.target?.toVector() ?: return InteractionResultHolder.pass(player.getItemInHand(hand)))
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
@@ -147,12 +141,12 @@ class ChainVisStraightenItem(properties: Properties) : Item(properties) {
 class SwitchGaitItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val bukkitPlayer = toBukkit(player)
-        playSound(level, player.position(), SoundEvents.DISPENSER_FAIL, 1.0f, 2.0f)
+        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
         AppState.gallop = !AppState.gallop
         SpiderConfig.GALLOP.set(AppState.gallop)
         SpiderConfig.save()
-        sendActionBar(bukkitPlayer, if (!AppState.gallop) "Walk mode" else "Gallop mode")
+        val message = if (!AppState.gallop) "Walk mode" else "Gallop mode"
+        player.displayClientMessage(Component.literal(message), true)
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }
@@ -161,10 +155,9 @@ class LaserPointerItem(properties: Properties) : Item(properties) {
     override fun inventoryTick(stack: ItemStack, level: Level, entity: Entity, slot: Int, selected: Boolean) {
         if (level.isClientSide) return
         if (entity is ServerPlayer && (entity.mainHandItem == stack || entity.offhandItem == stack)) {
-            val bukkitPlayer = toBukkit(entity)
             val eye = entity.eyePosition
             val directionVec = entity.lookAngle
-            val result = raycastGround(entity.level(), eye, directionVec, 100.0)
+            val result = level.raycastGround(eye, directionVec, 100.0)
             if (result == null) {
                 val direction = org.bukkit.util.Vector(directionVec.x, 0.0, directionVec.z).normalize()
                 AppState.spider?.let { it.behaviour = DirectionBehaviour(it, direction, direction) }
@@ -176,7 +169,7 @@ class LaserPointerItem(properties: Properties) : Item(properties) {
                 val targetVal = result.location
                 AppState.target = targetVal
                 AppState.chainVisualizer?.let {
-                    it.target = org.bukkit.Location(bukkitPlayer.world, targetVal.x, targetVal.y, targetVal.z)
+                    it.target = org.bukkit.Location(it.world, targetVal.x, targetVal.y, targetVal.z)
                     it.resetIterator()
                 }
                 AppState.spider?.let { it.behaviour = TargetBehaviour(it, targetVal.toVector(), it.lerpedGait.bodyHeight) }
@@ -189,7 +182,6 @@ class ComeHereItem(properties: Properties) : Item(properties) {
     override fun inventoryTick(stack: ItemStack, level: Level, entity: Entity, slot: Int, selected: Boolean) {
         if (level.isClientSide) return
         if (entity is ServerPlayer && (entity.mainHandItem == stack || entity.offhandItem == stack)) {
-            val bukkitPlayer = toBukkit(entity)
             AppState.spider?.let {
                 val height = if (it.gait.straightenLegs) it.lerpedGait.bodyHeight * 2.0 else it.lerpedGait.bodyHeight * 5.0
                 val eye = entity.eyePosition


### PR DESCRIPTION
## Summary
- Drop Bukkit player helper and use `ServerPlayer` for orientation, raycasts, sounds, and messages
- Replace custom sound helper with direct `level.playSound` calls
- Use `displayClientMessage` for action-bar output and `raycastGround` for targeting

## Testing
- `gradle test` *(fails: Could not resolve all files for configuration ':compileClasspath'. Could not find net.minecraftforge:forge:1.20.1-47.3.0_mapped_official_1.20.1)*

------
https://chatgpt.com/codex/tasks/task_b_689a77a8de348329a1673331b670b5c0