### PR TITLE
Refactor debug rendering for vanilla display entities

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -133,7 +133,7 @@ class ChainVisStraightenItem(properties: Properties) : Item(properties) {
         if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
         val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
         level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
-        chain.straighten(chain.target?.toVector() ?: return InteractionResultHolder.pass(player.getItemInHand(hand)))
+        chain.straighten(chain.target ?: return InteractionResultHolder.pass(player.getItemInHand(hand)))
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }
@@ -169,7 +169,7 @@ class LaserPointerItem(properties: Properties) : Item(properties) {
                 val targetVal = result.location
                 AppState.target = targetVal
                 AppState.chainVisualizer?.let {
-                    it.target = org.bukkit.Location(it.world, targetVal.x, targetVal.y, targetVal.z)
+                    it.target = targetVal
                     it.resetIterator()
                 }
                 AppState.spider?.let { it.behaviour = TargetBehaviour(it, targetVal.toVector(), it.lerpedGait.bodyHeight) }

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
@@ -79,6 +79,8 @@ class SpiderAnimationMod {
             // the Vec3 migration, so no marker is drawn until a replacement exists.
         }
 
+        AppState.chainVisualizer?.render()
+
         AppState.renderer.flush()
         AppState.target = null
     }

--- a/src/main/kotlin/com/heledron/spideranimation/kinematic_chain_visualizer/KinematicChainVisualizer.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/kinematic_chain_visualizer/KinematicChainVisualizer.kt
@@ -1,61 +1,56 @@
 package com.heledron.spideranimation.kinematic_chain_visualizer
 
+import com.heledron.spideranimation.AppState
 import com.heledron.spideranimation.spider.configuration.SegmentPlan
 import com.heledron.spideranimation.utilities.*
-import org.bukkit.Location
-import org.bukkit.Material
-import org.bukkit.World
-import org.bukkit.entity.Display
-import org.bukkit.util.Vector
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.entity.Display
+import net.minecraft.world.level.block.Block
+import net.minecraft.world.level.block.Blocks
+import net.minecraft.world.phys.Vec3
 import org.joml.Matrix4f
 import org.joml.Quaternionf
 import java.io.Closeable
 
-
 class KinematicChainVisualizer(
-//    val root: Location,
-    val world: World,
-    val root: Vector,
+    val world: ServerLevel,
+    val root: Vec3,
     val segments: List<ChainSegment>,
     val segmentPlans: List<SegmentPlan>,
-    val straightenRotation: Float
-): Closeable {
-    enum class Stage {
-        Backwards,
-        Forwards
-    }
+    val straightenRotation: Float,
+) : Closeable {
+    enum class Stage { Backwards, Forwards }
 
     val interruptions = mutableListOf<() -> Unit>()
     var iterator = 0
     var previous: Triple<Stage, Int, List<ChainSegment>>? = null
     var stage = Stage.Forwards
-    var target: Location? = null
+    var target: Vec3? = null
 
     var detailed = false
-    set(value) {
-        field = value
-        interruptions.clear()
-        render()
-    }
-
-    val renderer = GroupEntityRenderer()
-    override fun close() {
-        renderer.close()
-    }
+        set(value) {
+            field = value
+            interruptions.clear()
+            render()
+        }
 
     init {
         reset()
         render()
     }
 
+    override fun close() {
+        AppState.renderer.detach(this)
+    }
+
     companion object {
         fun create(
             segmentPlans: List<SegmentPlan>,
-            root: Vector,
-            world: World,
+            root: Vec3,
+            world: ServerLevel,
             straightenRotation: Float
         ): KinematicChainVisualizer {
-            val segments = segmentPlans.map { ChainSegment(root.clone(), it.length, it.initDirection) }
+            val segments = segmentPlans.map { ChainSegment(root, it.length, it.initDirection) }
             return KinematicChainVisualizer(world, root, segments, segmentPlans, straightenRotation)
         }
     }
@@ -72,14 +67,14 @@ class KinematicChainVisualizer(
 
         target = null
 
-        val direction = Vector(0, 1, 0)
-        val rotAxis = Vector(1, 0, -1)
+        var direction = Vec3(0.0, 1.0, 0.0)
+        val rotAxis = Vec3(1.0, 0.0, -1.0)
         val rotation = -0.2
-        val pos = root.clone()
+        var pos = root
         for (segment in segments) {
-            direction.rotateAroundAxis(rotAxis, rotation)
-            pos.add(direction.clone().multiply(segment.length))
-            segment.position.copy(pos)
+            direction = direction.rotateAroundAxis(rotAxis, rotation)
+            pos = pos.add(direction.scale(segment.length))
+            segment.position = pos
         }
 
         render()
@@ -91,7 +86,7 @@ class KinematicChainVisualizer(
             return
         }
 
-        val target = target?.toVector() ?: return
+        val target = target ?: return
 
         previous = Triple(stage, iterator, segments.map { it.clone() })
 
@@ -100,32 +95,30 @@ class KinematicChainVisualizer(
             val nextSegment = segments.getOrNull(iterator + 1)
 
             if (nextSegment == null) {
-                segment.position.copy(target)
+                segment.position = target
             } else {
-                fabrik_moveSegment(segment.position, nextSegment.position, nextSegment.length)
+                segment.position = fabrik_moveSegment(segment.position, nextSegment.position, nextSegment.length)
             }
 
-            if (iterator == 0) stage = Stage.Backwards
-            else iterator--
+            if (iterator == 0) stage = Stage.Backwards else iterator--
         } else {
             val segment = segments[iterator]
             val prevPosition = segments.getOrNull(iterator - 1)?.position ?: root
 
-            fabrik_moveSegment(segment.position, prevPosition, segment.length)
+            segment.position = fabrik_moveSegment(segment.position, prevPosition, segment.length)
 
-            if (iterator == segments.size - 1) stage = Stage.Forwards
-            else iterator++
+            if (iterator == segments.size - 1) stage = Stage.Forwards else iterator++
         }
 
         render()
     }
 
-    fun straighten(target: Vector) {
+    fun straighten(target: Vec3) {
         resetIterator()
 
         val pivot = Quaternionf()
 
-        val direction = target.clone().subtract(root).normalize()
+        val direction = target.subtract(root).normalize()
         val rotation = direction.getRotationAroundAxis(pivot)
 
         rotation.x += straightenRotation
@@ -136,19 +129,14 @@ class KinematicChainVisualizer(
         render()
     }
 
-    fun fabrik_moveSegment(point: Vector, pullTowards: Vector, segment: Double) {
-        val direction = pullTowards.clone().subtract(point).normalize()
-        point.copy(pullTowards).subtract(direction.multiply(segment))
+    private fun fabrik_moveSegment(point: Vec3, pullTowards: Vec3, segment: Double): Vec3 {
+        val direction = pullTowards.subtract(point).normalize()
+        return pullTowards.subtract(direction.scale(segment))
     }
 
     fun render() {
-        if (detailed) {
-            renderer.render(renderDetailed())
-        } else {
-            val model = renderNormal()
-            renderer.render(model)
-        }
-
+        val group = if (detailed) renderDetailed() else renderNormal()
+        AppState.renderer.render(this, group)
     }
 
     private fun renderNormal(): RenderEntityGroup {
@@ -163,27 +151,27 @@ class KinematicChainVisualizer(
 
             val list = if (previous == null || i == previous.second) segments else previous.third
 
-            val prev = list.getOrNull(i - 1)?.position ?: root.clone()
-            val vector = segment.position.clone().subtract(prev)
-            if (!vector.isZero) vector.normalize().multiply(segment.length)
-            val position = segment.position.clone().subtract(vector.clone())
+            val prev = list.getOrNull(i - 1)?.position ?: root
+            var vector = segment.position.subtract(prev)
+            if (vector != Vec3.ZERO) vector = vector.normalize().scale(segment.length)
+            val position = segment.position.subtract(vector)
 
             val rotation = KinematicChain(root, list).getRotations(pivot)[i]
             val transform = Matrix4f().rotate(rotation)
 
             for (piece in segmentPlan.model.pieces) {
                 group.add(i to piece, blockRenderEntity(
-                    world = world,
+                    level = world,
                     position = position,
                     init = {
-                        it.teleportDuration = 3
-                        it.interpolationDuration = 3
+                        it.setTeleportDuration(3)
+                        it.setInterpolationDuration(3)
                     },
                     update = {
                         val pieceTransform = Matrix4f(transform).mul(piece.transform)
                         it.applyTransformationWithInterpolation(pieceTransform)
-                        it.block = piece.block
-                        it.brightness = piece.brightness
+                        it.blockState = piece.block
+                        it.setBrightness(piece.brightness)
                     }
                 ))
             }
@@ -199,55 +187,47 @@ class KinematicChainVisualizer(
 
         var renderedSegments = segments
 
-        if (previous != null) run arrow@{
-            val (stage, iterator, segments) = previous
+        if (previous != null) run {
+            val (stage, iterator, segmentsPrev) = previous
 
             val arrowStart = if (stage == Stage.Forwards)
-                segments.getOrNull(iterator + 1)?.position else
-                segments.getOrNull(iterator - 1)?.position ?: root
+                segmentsPrev.getOrNull(iterator + 1)?.position
+            else
+                segmentsPrev.getOrNull(iterator - 1)?.position ?: root
 
-            if (arrowStart == null) return@arrow
-            renderedSegments = segments
+            if (arrowStart == null) return@run
+            renderedSegments = segmentsPrev
 
             if (subStage == 0) {
-                interruptions += { renderer.render(renderDetailed(1)) }
-                interruptions += { renderer.render(renderDetailed(2)) }
-                interruptions += { renderer.render(renderDetailed(3)) }
-                interruptions += { renderer.render(renderDetailed(4)) }
+                interruptions += { AppState.renderer.render(this@KinematicChainVisualizer, renderDetailed(1)) }
+                interruptions += { AppState.renderer.render(this@KinematicChainVisualizer, renderDetailed(2)) }
+                interruptions += { AppState.renderer.render(this@KinematicChainVisualizer, renderDetailed(3)) }
+                interruptions += { AppState.renderer.render(this@KinematicChainVisualizer, renderDetailed(4)) }
             }
 
-            // stage 0: subtract vector
-            val arrow = segments[iterator].position.clone().subtract(arrowStart)
+            var arrow = segmentsPrev[iterator].position.subtract(arrowStart)
 
-            // stage 1: normalise vector
-            if (subStage >= 1) arrow.normalize()
-
-            // stage 2: multiply by length
-            if (subStage >= 2) arrow.multiply(segments[iterator].length)
-
-            // stage 3: move segment
+            if (subStage >= 1) arrow = arrow.normalize()
+            if (subStage >= 2) arrow = arrow.scale(segmentsPrev[iterator].length)
             if (subStage >= 3) renderedSegments = this.segments
-
-            // stage 4: hide arrow
-            if (subStage >= 4) return@arrow
-
+            if (subStage >= 4) return@run
 
             val crossProduct = if (arrow == UP_VECTOR) FORWARD_VECTOR else
-                arrow.clone().crossProduct(UP_VECTOR).normalize()
+                arrow.cross(UP_VECTOR).normalize()
 
-            val arrowCenter = arrowStart.clone()
-                .add(arrow.clone().multiply(0.5))
-                .add(crossProduct.rotateAroundAxis(arrow, Math.toRadians(-90.0)).multiply(.5))
+            val arrowCenter = arrowStart
+                .add(arrow.scale(0.5))
+                .add(crossProduct.rotateAroundAxis(arrow, Math.toRadians(-90.0)).scale(.5))
 
             group.add("arrow_length", textRenderEntity(
-                world = world,
+                level = world,
                 position = arrowCenter,
                 text = String.format("%.2f", arrow.length()),
                 interpolation = 3,
             ))
 
             group.add("arrow", arrowRenderEntity(
-                world = world,
+                level = world,
                 position = arrowStart,
                 vector = arrow,
                 thickness = .101f,
@@ -255,25 +235,26 @@ class KinematicChainVisualizer(
             ))
         }
 
-        group.add("root", pointRenderEntity(world, root, Material.DIAMOND_BLOCK))
+        group.add("root", pointRenderEntity(world, root, Blocks.DIAMOND_BLOCK))
 
         for (i in renderedSegments.indices) {
             val segment = renderedSegments[i]
-            group.add("p$i", pointRenderEntity(world, segment.position, Material.EMERALD_BLOCK))
+            group.add("p$i", pointRenderEntity(world, segment.position, Blocks.EMERALD_BLOCK))
 
             val prev = renderedSegments.getOrNull(i - 1)?.position ?: root
 
-            val (a,b) = prev to segment.position
+            val a = prev
+            val b = segment.position
 
             group.add(i, lineRenderEntity(
-                world = world,
+                level = world,
                 position = a,
-                vector = b.clone().subtract(a),
+                vector = b.subtract(a),
                 thickness = .1f,
                 interpolation = 3,
                 update = {
-                    it.brightness = Display.Brightness(0, 15)
-                    it.block = Material.BLACK_STAINED_GLASS.createBlockData()
+                    it.setBrightness(Display.Brightness(0, 15))
+                    it.blockState = Blocks.BLACK_STAINED_GLASS.defaultBlockState()
                 }
             ))
         }
@@ -282,65 +263,65 @@ class KinematicChainVisualizer(
     }
 }
 
-fun pointRenderEntity(world: World, position: Vector, block: Material) = blockRenderEntity(
-    world = world,
+private fun pointRenderEntity(level: ServerLevel, position: Vec3, block: Block) = blockRenderEntity(
+    level = level,
     position = position,
     init = {
-        it.block = block.createBlockData()
-        it.teleportDuration = 3
-        it.brightness = Display.Brightness(15, 15)
+        it.blockState = block.defaultBlockState()
+        it.setTeleportDuration(3)
+        it.setBrightness(Display.Brightness(15, 15))
         it.transformation = centredTransform(.26f, .26f, .26f)
     }
 )
 
-fun arrowRenderEntity(
-    world: World,
-    position: Vector,
-    vector: Vector,
+private fun arrowRenderEntity(
+    level: ServerLevel,
+    position: Vec3,
+    vector: Vec3,
     thickness: Float,
     interpolation: Int
 ): RenderEntityGroup {
     val line = lineRenderEntity(
-        world = world,
+        level = level,
         position = position,
         vector = vector,
         thickness = thickness,
         interpolation = interpolation,
         init = {
-            it.block = Material.GOLD_BLOCK.createBlockData()
-            it.brightness = Display.Brightness(0, 15)
+            it.blockState = Blocks.GOLD_BLOCK.defaultBlockState()
+            it.setBrightness(Display.Brightness(0, 15))
         },
     )
 
     val tipLength = 0.5
-    val tip = position.clone().add(vector)
+    val tip = position.add(vector)
     val crossProduct = if (vector == UP_VECTOR) FORWARD_VECTOR else
-        vector.clone().crossProduct(UP_VECTOR).normalize().multiply(tipLength)
+        vector.cross(UP_VECTOR).normalize().scale(tipLength)
 
-    val tipDirection = vector.clone().normalize().multiply(-tipLength)
+    val tipDirection = vector.normalize().scale(-tipLength)
     val tipRotation = 30.0
 
     val top = lineRenderEntity(
-        world = world,
+        level = level,
         position = tip,
-        vector = tipDirection.clone().rotateAroundAxis(crossProduct, Math.toRadians(tipRotation)),
+        vector = tipDirection.rotateAroundAxis(crossProduct, Math.toRadians(tipRotation)),
         thickness = thickness,
         interpolation = interpolation,
         init = {
-            it.block = Material.GOLD_BLOCK.createBlockData()
-            it.brightness = Display.Brightness(0, 15)
+            it.blockState = Blocks.GOLD_BLOCK.defaultBlockState()
+            it.setBrightness(Display.Brightness(0, 15))
         },
     )
 
     val bottom = lineRenderEntity(
-        world = world,
+        level = level,
         position = tip,
-        vector = tipDirection.clone().rotateAroundAxis(crossProduct, Math.toRadians(-tipRotation)),
+        vector = tipDirection.rotateAroundAxis(crossProduct, Math.toRadians(-tipRotation)),
         thickness = thickness,
         interpolation = interpolation,
         init = {
-            it.block = Material.GOLD_BLOCK.createBlockData()
-            it.brightness = Display.Brightness(0, 15)
+            it.blockState = Blocks.GOLD_BLOCK.defaultBlockState()
+            it.setBrightness(Display.Brightness(0, 15))
         },
     )
 
@@ -350,3 +331,11 @@ fun arrowRenderEntity(
         add("bottom", bottom)
     }
 }
+
+private fun Vec3.rotateAroundAxis(axis: Vec3, angle: Double): Vec3 {
+    val q = Quaternionf().rotateAxis(angle.toFloat(), axis.toVector3f())
+    val vec = this.toVector3f()
+    q.transform(vec)
+    return vec.toVec3()
+}
+

--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderDebugRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderDebugRenderEntities.kt
@@ -5,7 +5,6 @@ import com.heledron.spideranimation.utilities.*
 import net.minecraft.world.entity.Display
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.phys.Vec3
-import org.bukkit.util.Vector
 import org.joml.Matrix4f
 import org.joml.Quaternionf
 import org.joml.Vector3f
@@ -147,7 +146,7 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
 
     // Render preferred orientation
     if (spider.options.debug.preferredOrientation) {
-        fun renderEntity(orientation: Quaternionf, direction: Vector, thickness: Float, length: Float, block: net.minecraft.world.level.block.Block) = run {
+        fun renderEntity(orientation: Quaternionf, direction: Vec3, thickness: Float, length: Float, block: net.minecraft.world.level.block.Block) = run {
             val mTranslation = Vector3f(-1f, -1f, -1f).add(direction.toVector3f()).mul(.5f)
             val mScale = Vector3f(thickness, thickness, thickness).add(direction.toVector3f().mul(length))
 

--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderRenderEntities.kt
@@ -6,7 +6,6 @@ import com.heledron.spideranimation.utilities.Brightness
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.phys.Vec3
-import org.bukkit.util.Vector
 import org.joml.Matrix4f
 import org.joml.Vector4f
 
@@ -31,7 +30,6 @@ fun spiderRenderEntities(spider: Spider): RenderEntityGroup {
     val transform = Matrix4f().rotate(spider.orientation)
     group.add(spider.body, modelToRenderEntity(spider, spider.position, spider.options.bodyPlan.bodyModel, transform))
 
-
     for ((legIndex, leg) in spider.body.legs.withIndex()) {
         val chain = leg.chain
 
@@ -43,7 +41,6 @@ fun spiderRenderEntities(spider: Spider): RenderEntityGroup {
 
             val segmentTransform = Matrix4f().rotate(rotation)
             group.add(legIndex to segmentIndex, modelToRenderEntity(spider, parent, segmentPlan.model, segmentTransform))
-
         }
     }
 
@@ -52,7 +49,7 @@ fun spiderRenderEntities(spider: Spider): RenderEntityGroup {
 
 private fun modelToRenderEntity(
     spider: Spider,
-    position: Vector,
+    position: Vec3,
     model: DisplayModel,
     transformation: Matrix4f
 ): RenderEntityGroup {
@@ -65,15 +62,14 @@ private fun modelToRenderEntity(
     return group
 }
 
-
 private fun modelPieceToRenderEntity(
     spider: Spider,
-    position: Vector,
+    position: Vec3,
     piece: BlockDisplayModelPiece,
     transformation: Matrix4f,
 ) = blockRenderEntity(
     level = spider.world,
-    position = position.toVec3(),
+    position = position,
     init = {
         it.setTeleportDuration(1)
         it.setInterpolationDuration(1)
@@ -84,12 +80,13 @@ private fun modelPieceToRenderEntity(
 
         val cloak = if (piece.tags.contains("cloak")) {
             val relative = transform.transform(Vector4f(.5f, .5f, .5f, 1f))
-            val piecePosition = position.clone()
-            piecePosition.x += relative.x
-            piecePosition.y += relative.y
-            piecePosition.z += relative.z
+            val piecePosition = Vec3(
+                position.x + relative.x.toDouble(),
+                position.y + relative.y.toDouble(),
+                position.z + relative.z.toDouble(),
+            )
 
-            spider.cloak.getPiece(piece, piecePosition.toVec3(), piece.block, piece.brightness)
+            spider.cloak.getPiece(piece, piecePosition, piece.block, piece.brightness)
         } else null
 
         if (cloak != null) {
@@ -99,5 +96,5 @@ private fun modelPieceToRenderEntity(
             it.blockState = piece.block
             it.setBrightness(piece.brightness)
         }
-    }
+    },
 )


### PR DESCRIPTION
## Summary
- Introduce MultiEntityRenderer and port rendering helpers to vanilla BlockDisplay with Matrix4f transforms
- Migrate kinematic chain visualizer and spider renderers to ServerLevel/Vec3 and BlockState-based debug markers
- Hook chain visualizer and debug toggles into MultiEntityRenderer for display entity support

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching {languageVersion=17})*

------
https://chatgpt.com/codex/tasks/task_b_689a7ab155a883299d9e800cdd806b6e