### PR TITLE
Ensure server-side handling for spider interactions

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -111,9 +111,8 @@ class SwitchRendererItem(properties: Properties) : Item(properties) {
 
 class ToggleCloakItem(properties: Properties) : Item(properties) {
     override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (!level.isClientSide) {
-            AppState.spider?.cloak?.toggleCloak()
-        }
+        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
+        AppState.spider?.cloak?.toggleCloak()
         return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
     }
 }

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
@@ -87,6 +87,7 @@ class SpiderAnimationMod {
 
     @SubscribeEvent
     fun onEntityJoin(event: EntityJoinLevelEvent) {
+        if (event.level.isClientSide) return
         if (!event.entity.tags.contains("spider.chain_visualizer")) return
         val segmentPlans = AppState.options.bodyPlan.legs.lastOrNull()?.segments ?: return
         val level = event.level as? ServerLevel ?: return


### PR DESCRIPTION
## Summary
- Gate mount interaction and rider movement to the server thread and use server-recognized movement fields
- Ignore client worlds when spawning the chain visualizer
- Only toggle the spider cloak on the server

## Testing
- `gradle build` *(fails: Could not resolve external dependencies because no repositories are defined)*

------
https://chatgpt.com/codex/tasks/task_b_689a8cadc510832983364178db5da576