### PR TITLE
refactor: replace Bukkit Vector with Vec3

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -158,7 +158,7 @@ class LaserPointerItem(properties: Properties) : Item(properties) {
             val directionVec = entity.lookAngle
             val result = level.raycastGround(eye, directionVec, 100.0)
             if (result == null) {
-                val direction = org.bukkit.util.Vector(directionVec.x, 0.0, directionVec.z).normalize()
+                val direction = Vec3(directionVec.x, 0.0, directionVec.z).normalize()
                 AppState.spider?.let { it.behaviour = DirectionBehaviour(it, direction, direction) }
                 AppState.chainVisualizer?.let {
                     it.target = null
@@ -171,7 +171,7 @@ class LaserPointerItem(properties: Properties) : Item(properties) {
                     it.target = targetVal
                     it.resetIterator()
                 }
-                AppState.spider?.let { it.behaviour = TargetBehaviour(it, targetVal.toVector(), it.lerpedGait.bodyHeight) }
+                AppState.spider?.let { it.behaviour = TargetBehaviour(it, targetVal, it.lerpedGait.bodyHeight) }
             }
         }
     }
@@ -184,7 +184,7 @@ class ComeHereItem(properties: Properties) : Item(properties) {
             AppState.spider?.let {
                 val height = if (it.gait.straightenLegs) it.lerpedGait.bodyHeight * 2.0 else it.lerpedGait.bodyHeight * 5.0
                 val eye = entity.eyePosition
-                it.behaviour = TargetBehaviour(it, org.bukkit.util.Vector(eye.x, eye.y, eye.z), height)
+                it.behaviour = TargetBehaviour(it, Vec3(eye.x, eye.y, eye.z), height)
             }
         }
     }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/Spider.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/Spider.kt
@@ -49,10 +49,10 @@ class Spider(
     var isRotatingYaw = false
 //    var isRotatingPitch = false
 
-    val velocity = Vector(0.0, 0.0, 0.0)
+    var velocity = Vec3(0.0, 0.0, 0.0)
     val rotationalVelocity = Vector3f(0f,0f,0f)
 
-    fun accelerateRotation(axis: Vector, angle: Float) {
+    fun accelerateRotation(axis: Vec3, angle: Float) {
         val acceleration = Quaternionf().rotateAxis(angle, axis.toVector3f())
         val oldVelocity = Quaternionf().rotationYXZ(rotationalVelocity.y, rotationalVelocity.x, rotationalVelocity.z)
 
@@ -136,8 +136,7 @@ class Spider(
             return
         }
 
-        fun getPos(leg: Leg): Vector {
-//            if (leg.isOutsideTriggerZone) return leg.endEffector
+        fun getPos(leg: Leg): Vec3 {
             return leg.groundPosition ?: leg.restPosition
         }
 
@@ -146,16 +145,16 @@ class Spider(
         val backLeft  = getPos(body.legs.getOrNull(body.legs.size - 2) ?: return)
         val backRight = getPos(body.legs.getOrNull(body.legs.size - 1) ?: return)
 
-        val forwardLeft = frontLeft.clone().subtract(backLeft)
-        val forwardRight = frontRight.clone().subtract(backRight)
-        val forward = listOf(forwardLeft, forwardRight).average()
+        val forwardLeftVec = frontLeft.subtract(backLeft)
+        val forwardRightVec = frontRight.subtract(backRight)
+        val forward = listOf(forwardLeftVec, forwardRightVec).average()
 
-        val sideways = Vector(0.0,0.0,0.0)
+        var sideways = Vec3(0.0,0.0,0.0)
         for (i in 0 until body.legs.size step 2) {
             val left = body.legs.getOrNull(i) ?: continue
             val right = body.legs.getOrNull(i + 1) ?: continue
 
-            sideways.add(getPos(right).clone().subtract(getPos(left)))
+            sideways = sideways.add(getPos(right).subtract(getPos(left)))
         }
 
         preferredPitch = forward.getPitch().lerp(preferredPitch, gait.preferredRotationLerpFraction)

--- a/src/main/kotlin/com/heledron/spideranimation/spider/body/SpiderBody.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/body/SpiderBody.kt
@@ -3,7 +3,7 @@ package com.heledron.spideranimation.spider.body
 import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.spider.SpiderComponent
 import com.heledron.spideranimation.utilities.*
-import org.bukkit.util.Vector
+import net.minecraft.world.phys.Vec3
 import org.joml.Quaternionf
 import org.joml.Vector2d
 import org.joml.Vector3f
@@ -14,15 +14,15 @@ class SpiderBody(val spider: Spider): SpiderComponent {
     var onGround = false; private set
     var legs = spider.options.bodyPlan.legs.map { Leg(spider, it) }
     var normal: NormalInfo? = null; private set
-    var normalAcceleration = Vector(0.0, 0.0, 0.0); private set
+    var normalAcceleration = Vec3(0.0, 0.0, 0.0); private set
 
     override fun update() {
         val groundedLegs = legs.filter { it.isGrounded() }
         val fractionOfLegsGrounded = groundedLegs.size.toDouble() / spider.body.legs.size
 
         // apply gravity and air resistance
-        spider.velocity.y -= spider.gait.gravityAcceleration
-        spider.velocity.y *= (1 - spider.gait.airDragCoefficient)
+        spider.velocity = spider.velocity.setY(spider.velocity.y - spider.gait.gravityAcceleration)
+        spider.velocity = spider.velocity.setY(spider.velocity.y * (1 - spider.gait.airDragCoefficient))
 
         // apply rotational velocity
         val rotVelocity = Quaternionf().rotationYXZ(spider.rotationalVelocity.y, spider.rotationalVelocity.x, spider.rotationalVelocity.z)
@@ -31,8 +31,7 @@ class SpiderBody(val spider: Spider): SpiderComponent {
         // apply drag while leg on ground
         if (!spider.isWalking) {
             val legDrag = 1 - spider.gait.groundDragCoefficient * fractionOfLegsGrounded
-            spider.velocity.x *= legDrag
-            spider.velocity.z *= legDrag
+            spider.velocity = Vec3(spider.velocity.x * legDrag, spider.velocity.y, spider.velocity.z * legDrag)
         }
 
         // apply rotational drag
@@ -42,8 +41,7 @@ class SpiderBody(val spider: Spider): SpiderComponent {
         // apply drag while body on ground
         if (onGround) {
             val bodyDrag = .5f
-            spider.velocity.x *= bodyDrag
-            spider.velocity.z *= bodyDrag
+            spider.velocity = Vec3(spider.velocity.x * bodyDrag, spider.velocity.y, spider.velocity.z * bodyDrag)
 
             spider.rotationalVelocity.mul(bodyDrag)
         }
@@ -51,36 +49,36 @@ class SpiderBody(val spider: Spider): SpiderComponent {
         val normal = getNormal(spider)
         this.normal = normal
 
-        normalAcceleration = Vector(0.0, 0.0, 0.0)
+        normalAcceleration = Vec3(0.0, 0.0, 0.0)
         if (normal != null) {
             val preferredY = getPreferredY()
             val preferredYAcceleration = (preferredY - spider.position.y - spider.velocity.y).coerceAtLeast(0.0)
             val capableAcceleration = spider.gait.bodyHeightCorrectionAcceleration * fractionOfLegsGrounded
             val accelerationMagnitude = min(preferredYAcceleration, capableAcceleration)
 
-            normalAcceleration = normal.normal.clone().multiply(accelerationMagnitude)
+            normalAcceleration = normal.normal.scale(accelerationMagnitude)
 
             // if the horizontal acceleration is too high,
             // there's no point accelerating as the spider will fall over anyway
-            if (normalAcceleration.horizontalLength() > normalAcceleration.y) normalAcceleration.multiply(0.0)
+            if (normalAcceleration.horizontalLength() > normalAcceleration.y) normalAcceleration = normalAcceleration.scale(0.0)
 
-            spider.velocity.add(normalAcceleration)
+            spider.velocity = spider.velocity.add(normalAcceleration)
         }
 
         // apply velocity
-        spider.position.add(spider.velocity)
+        spider.position = spider.position.add(spider.velocity)
 
         // resolve collision
-        val collision = spider.world.resolveCollision(spider.position, Vector(0.0, min(-1.0, -abs(spider.velocity.y)), 0.0))
+        val collision = spider.world.resolveCollision(spider.position, Vec3(0.0, min(-1.0, -abs(spider.velocity.y)), 0.0))
         if (collision != null) {
             onGround = true
 
             val didHit = collision.offset.length() > (spider.gait.gravityAcceleration * 2) * (1 - spider.gait.airDragCoefficient)
             if (didHit) onHitGround.emit()
 
-            spider.position.y = collision.position.y
-            if (spider.velocity.y < 0) spider.velocity.y *= -spider.gait.bounceFactor
-            if (spider.velocity.y < spider.gait.gravityAcceleration) spider.velocity.y = .0
+            spider.position = spider.position.setY(collision.position.y)
+            if (spider.velocity.y < 0) spider.velocity = spider.velocity.setY(spider.velocity.y * -spider.gait.bounceFactor)
+            if (spider.velocity.y < spider.gait.gravityAcceleration) spider.velocity = spider.velocity.setY(.0)
         } else {
             onGround = spider.world.isOnGround(spider.position, DOWN_VECTOR.rotate(spider.orientation))
         }
@@ -91,14 +89,14 @@ class SpiderBody(val spider: Spider): SpiderComponent {
     }
 
     private fun getPreferredY(): Double {
-        val lookAhead = spider.position.clone().add(spider.velocity)
+        val lookAhead = spider.position.add(spider.velocity)
         val ground = spider.world.raycastGround(lookAhead, DOWN_VECTOR.rotate(spider.preferredOrientation), spider.lerpedGait.bodyHeight)
         val groundY = ground?.hitPosition?.y ?: -Double.MAX_VALUE
 
         val averageY = spider.body.legs.map { it.target.position.y }.average() + spider.lerpedGait.bodyHeight
 
         val pivot = spider.gait.legChainPivotMode.get(spider)
-        val target = UP_VECTOR.rotate(pivot).multiply(spider.gait.maxBodyDistanceFromGround)
+        val target = UP_VECTOR.rotate(pivot).scale(spider.gait.maxBodyDistanceFromGround)
         val targetY = max(averageY, groundY + target.y)
         val stabilizedY = spider.position.y.lerp(targetY, spider.gait.bodyHeightCorrectionFactor)
 
@@ -114,7 +112,7 @@ class SpiderBody(val spider: Spider): SpiderComponent {
     private fun getLegacyNormal(): NormalInfo? {
         val pairs = LegLookUp.diagonalPairs(legs.indices.toList())
         if (pairs.any { pair -> pair.mapNotNull { spider.body.legs.getOrNull(it) }.all { it.isGrounded() } }) {
-            return NormalInfo(normal = Vector(0, 1, 0))
+            return NormalInfo(normal = Vec3(0.0, 1.0, 0.0))
         }
 
         return null
@@ -123,21 +121,21 @@ class SpiderBody(val spider: Spider): SpiderComponent {
     private fun getNormal(spider: Spider): NormalInfo? {
         if (spider.gait.useLegacyNormalForce) return getLegacyNormal()
 
-        val centreOfMass = spider.body.legs.map { it.endEffector }.average()
-        centreOfMass.lerp(spider.position, 0.5)
-        centreOfMass.y += 0.01
+        var centreOfMass = spider.body.legs.map { it.endEffector }.average()
+        centreOfMass = centreOfMass.lerp(spider.position, 0.5)
+        centreOfMass = centreOfMass.setY(centreOfMass.y + 0.01)
 
         val groundedLegs = legsInPolygonalOrder().map { spider.body.legs[it] }.filter { it.isGrounded() }
         if (groundedLegs.isEmpty()) return null
 
-        val legsPolygon = groundedLegs.map { it.endEffector.clone() }
+        val legsPolygon = groundedLegs.map { it.endEffector }
         val polygonCenterY = legsPolygon.map { it.y }.average()
 
         // only 1 leg on ground
         if (legsPolygon.size == 1) {
-            val origin = groundedLegs.first().endEffector.clone()
+            val origin = groundedLegs.first().endEffector
             return NormalInfo(
-                normal = centreOfMass.clone().subtract(origin).normalize(),
+                normal = centreOfMass.subtract(origin).normalize(),
                 origin = origin,
                 centreOfMass = centreOfMass,
                 contactPolygon = legsPolygon
@@ -148,17 +146,17 @@ class SpiderBody(val spider: Spider): SpiderComponent {
 
         // inside polygon. accelerate upwards towards centre of mass
         if (pointInPolygon(Vector2d(centreOfMass.x, centreOfMass.z), polygon2D)) return NormalInfo(
-            normal = Vector(0, 1, 0),
-            origin = Vector(centreOfMass.x, polygonCenterY, centreOfMass.z),
+            normal = Vec3(0.0, 1.0, 0.0),
+            origin = Vec3(centreOfMass.x, polygonCenterY, centreOfMass.z),
             centreOfMass = centreOfMass,
             contactPolygon = legsPolygon
         )
 
         // outside polygon, accelerate at an angle from within the polygon
         val point = nearestPointInPolygon(Vector2d(centreOfMass.x, centreOfMass.z), polygon2D)
-        val origin = Vector(point.x, polygonCenterY, point.y)
+        val origin = Vec3(point.x, polygonCenterY, point.y)
         return NormalInfo(
-            normal = centreOfMass.clone().subtract(origin).normalize(),
+            normal = centreOfMass.subtract(origin).normalize(),
             origin = origin,
             centreOfMass = centreOfMass,
             contactPolygon = legsPolygon
@@ -169,22 +167,23 @@ class SpiderBody(val spider: Spider): SpiderComponent {
         if (normal.origin == null) return
         if (normal.centreOfMass == null) return
 
-        if (normal.origin.horizontalDistance(normal.centreOfMass) < spider.gait.polygonLeeway) {
-            normal.origin.x = normal.centreOfMass.x
-            normal.origin.z = normal.centreOfMass.z
+        val origin = normal.origin!!
+        val centre = normal.centreOfMass!!
+        if (origin.horizontalDistance(centre) < spider.gait.polygonLeeway) {
+            normal.origin = Vec3(centre.x, origin.y, centre.z)
         }
 
-        val stabilizationTarget = normal.origin.clone().setY(normal.centreOfMass.y)
-        normal.centreOfMass.lerp(stabilizationTarget, spider.gait.stabilizationFactor)
+        val stabilizationTarget = origin.setY(centre.y)
+        normal.centreOfMass = centre.lerp(stabilizationTarget, spider.gait.stabilizationFactor)
 
-        normal.normal.copy(normal.centreOfMass).subtract(normal.origin).normalize()
+        normal.normal = normal.centreOfMass!!.subtract(normal.origin!!).normalize()
     }
 }
 
 class NormalInfo(
     // most of these fields are only used for debug rendering
-    val normal: Vector,
-    val origin: Vector? = null,
-    val contactPolygon: List<Vector>? = null,
-    val centreOfMass: Vector? = null
+    var normal: Vec3,
+    var origin: Vec3? = null,
+    val contactPolygon: List<Vec3>? = null,
+    var centreOfMass: Vec3? = null
 )

--- a/src/main/kotlin/com/heledron/spideranimation/spider/configuration/BodyPlan.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/configuration/BodyPlan.kt
@@ -3,19 +3,19 @@ package com.heledron.spideranimation.spider.configuration
 import com.heledron.spideranimation.spider.presets.AnimatedPalettes
 import com.heledron.spideranimation.spider.presets.SpiderTorsoModels
 import com.heledron.spideranimation.utilities.DisplayModel
-import org.bukkit.util.Vector
+import net.minecraft.world.phys.Vec3
 
 class SegmentPlan(
     var length: Double,
-    var initDirection: Vector,
+    var initDirection: Vec3,
     var model: DisplayModel = DisplayModel(listOf())
 ) {
     fun clone() = SegmentPlan(length, initDirection.clone(), model.clone())
 }
 
 class LegPlan(
-    var attachmentPosition: Vector,
-    var restPosition: Vector,
+    var attachmentPosition: Vec3,
+    var restPosition: Vec3,
     var segments: List<SegmentPlan>,
 )
 
@@ -32,8 +32,8 @@ class BodyPlan {
         this.scale *= scale
         bodyModel.scale(scale.toFloat())
         legs.forEach {
-            it.attachmentPosition.multiply(scale)
-            it.restPosition.multiply(scale)
+            it.attachmentPosition = it.attachmentPosition.scale(scale)
+            it.restPosition = it.restPosition.scale(scale)
             it.segments.forEach { segment ->
                 segment.length *= scale
                 segment.model.scale(scale.toFloat())

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/Mountable.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/Mountable.kt
@@ -7,15 +7,14 @@ import net.minecraft.server.level.ServerPlayer
 import net.minecraft.sounds.SoundEvents
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.entity.animal.Pig
-import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.world.entity.EntityType
+import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.world.item.Items
 import net.minecraft.world.phys.Vec3
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.event.entity.EntityMountEvent
 import net.minecraftforge.event.entity.player.PlayerInteractEvent
 import net.minecraftforge.eventbus.api.SubscribeEvent
-import org.bukkit.util.Vector
 import org.joml.Quaternionf
 import java.io.Closeable
 
@@ -89,23 +88,23 @@ class Mountable(val spider: Spider): SpiderComponent {
             val look = player.lookAngle
             spider.behaviour = DirectionBehaviour(
                 spider,
-                Vector(look.x, look.y, look.z),
-                Vector(input.x, input.y, input.z)
+                Vec3(look.x, look.y, look.z),
+                Vec3(input.x, input.y, input.z)
             )
 
         }
     }
 
     override fun render() {
-        val location = Vector(spider.position.x, spider.position.y, spider.position.z).add(spider.velocity)
+        val location = spider.position.add(spider.velocity)
 
-        val pigLocation = location.clone().add(Vector(.0, -.6, .0))
-        val markerLocation = location.clone().add(Vector(.0, .3, .0))
+        val pigLocation = location.add(Vec3(.0, -.6, .0))
+        val markerLocation = location.add(Vec3(.0, .3, .0))
 
         pig.render(RenderEntity(
             type = EntityType.PIG,
             level = spider.world,
-            position = Vec3(pigLocation.x, pigLocation.y, pigLocation.z),
+            position = pigLocation,
             init = {
                 it.setNoGravity(true)
                 it.setNoAi(true)
@@ -119,7 +118,7 @@ class Mountable(val spider: Spider): SpiderComponent {
         marker.render(RenderEntity(
             type = EntityType.ARMOR_STAND,
             level = spider.world,
-            position = Vec3(markerLocation.x, markerLocation.y, markerLocation.z),
+            position = markerLocation,
             init = {
                 it.setNoGravity(true)
                 it.isInvisible = true

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/PointDetector.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/PointDetector.kt
@@ -4,7 +4,6 @@ import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.spider.SpiderComponent
 import com.heledron.spideranimation.spider.body.Leg
 import com.heledron.spideranimation.utilities.lookingAtPoint
-import com.heledron.spideranimation.utilities.toVec3
 import net.minecraft.server.level.ServerPlayer
 
 class PointDetector(val spider: Spider) : SpiderComponent {
@@ -22,7 +21,7 @@ class PointDetector(val spider: Spider) : SpiderComponent {
         val eye = player.eyePosition
         val direction = player.lookAngle
         for (leg in spider.body.legs) {
-            val lookingAt = lookingAtPoint(eye, direction, leg.endEffector.toVec3(), spider.lerpedGait.bodyHeight * .15)
+            val lookingAt = lookingAtPoint(eye, direction, leg.endEffector, spider.lerpedGait.bodyHeight * .15)
             if (lookingAt) return leg
         }
         return null

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/SoundsAndParticles.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/SoundsAndParticles.kt
@@ -6,13 +6,12 @@ import com.heledron.spideranimation.spider.body.Leg
 import com.heledron.spideranimation.spider.configuration.SoundPlayer
 import com.heledron.spideranimation.utilities.playSound
 import com.heledron.spideranimation.utilities.spawnParticle
-import com.heledron.spideranimation.utilities.toVec3
 import net.minecraft.core.BlockPos
 import net.minecraft.core.particles.ParticleTypes
 import net.minecraft.sounds.SoundEvents
 import net.minecraft.world.level.block.state.properties.BlockStateProperties
 import net.minecraft.world.level.material.Fluids
-import org.bukkit.util.Vector
+import net.minecraft.world.phys.Vec3
 import java.io.Closeable
 import java.util.*
 import kotlin.random.Random
@@ -57,12 +56,12 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
                 val isUnderWater = isInWater(leg.endEffector)
                 val sound = if (isUnderWater) underwaterStepSound else spider.options.sound.step
 
-                sound.play(spider.world, leg.endEffector.toVec3())
+                sound.play(spider.world, leg.endEffector)
             }
         }
     }
 
-    private fun isInWater(position: Vector): Boolean {
+    private fun isInWater(position: Vec3): Boolean {
         val blockPos = BlockPos(position.x.toInt(), position.y.toInt(), position.z.toInt())
         val state = spider.world.getBlockState(blockPos)
         return state.fluidState.type == Fluids.WATER ||
@@ -90,19 +89,19 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
                 if (justEnteredWater) {
                     val volume = .3f
                     val pitch = 1.0f + Random.nextFloat() * 0.1f
-                    playSound(spider.world, leg.endEffector.toVec3(), SoundEvents.PLAYER_SPLASH, volume, pitch)
+                    playSound(spider.world, leg.endEffector, SoundEvents.PLAYER_SPLASH, volume, pitch)
                     timeSinceLastSound = 0
                 }
                 else if (justExitedWater) {
                     val volume = .3f
                     val pitch = 1f + Random.nextFloat() * 0.1f
-                    playSound(spider.world, leg.endEffector.toVec3(), SoundEvents.AMBIENT_UNDERWATER_EXIT, volume, pitch)
+                    playSound(spider.world, leg.endEffector, SoundEvents.AMBIENT_UNDERWATER_EXIT, volume, pitch)
                     timeSinceLastSound = 0
                 }
                 else if (justBegunMoving && isUnderWater) {
                     val volume = .3f
                     val pitch = .7f + Random.nextFloat() * 0.1f
-                    playSound(spider.world, leg.endEffector.toVec3(), SoundEvents.PLAYER_SWIM, volume, pitch)
+                    playSound(spider.world, leg.endEffector, SoundEvents.PLAYER_SWIM, volume, pitch)
                     timeSinceLastSound = 0
                 }
             }
@@ -113,7 +112,7 @@ class SoundsAndParticles(val spider: Spider) : SpiderComponent {
             for (segment in leg.chain.segments) {
                 val segmentIsUnderWater = isInWater(segment.position)
 
-                val location = segment.position.clone().add(0.0, -0.1, 0.0).toVec3()
+                val location = segment.position.add(0.0, -0.1, 0.0)
 
                 if (segmentIsUnderWater) {
                     if (justEnteredWater || justExitedWater) {

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/TridentHitDetector.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/TridentHitDetector.kt
@@ -5,7 +5,6 @@ import com.heledron.spideranimation.spider.SpiderComponent
 import com.heledron.spideranimation.utilities.EventEmitter
 import com.heledron.spideranimation.utilities.UP_VECTOR
 import com.heledron.spideranimation.utilities.runLater
-import com.heledron.spideranimation.utilities.toVector
 import net.minecraft.world.entity.projectile.ThrownTrident
 import net.minecraft.world.phys.AABB
 import org.joml.Vector3f
@@ -37,7 +36,7 @@ class TridentHitDetector(val spider: Spider): SpiderComponent {
                 trident.hasImpulse = true
                 onHit.emit()
 
-                spider.velocity.add(tridentDirection.scale(spider.gait.tridentKnockBack).toVector())
+                spider.velocity = spider.velocity.add(tridentDirection.scale(spider.gait.tridentKnockBack))
 
                 // apply rotational acceleration
                 val hitDirection = spider.position.subtract(trident.position()).normalize()
@@ -46,7 +45,7 @@ class TridentHitDetector(val spider: Spider): SpiderComponent {
 
                 val accelerationMagnitude = angle * spider.gait.tridentRotationalKnockBack.toFloat()
 
-                spider.accelerateRotation(axis.toVector(), accelerationMagnitude)
+                spider.accelerateRotation(axis, accelerationMagnitude)
             }
         }
     }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/splay.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/splay.kt
@@ -2,6 +2,7 @@ package com.heledron.spideranimation.spider.misc
 
 import com.heledron.spideranimation.AppState
 import com.heledron.spideranimation.utilities.*
+import net.minecraft.world.phys.Vec3
 import org.bukkit.entity.BlockDisplay
 import org.bukkit.util.Transformation
 import org.joml.Quaternionf
@@ -55,7 +56,7 @@ fun splay() {
     }
 
     for ((i, entity) in entities.withIndex().shuffled()) {
-        val offset = entity.location.toVector().subtract(spider.position)
+        val offset = Vec3(entity.location.x, entity.location.y, entity.location.z).subtract(spider.position)
 
         // normalize position
         entity.teleportDuration = 0

--- a/src/main/kotlin/com/heledron/spideranimation/spider/presets/presets.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/presets/presets.kt
@@ -6,48 +6,48 @@ import com.heledron.spideranimation.spider.configuration.SegmentPlan
 import com.heledron.spideranimation.spider.configuration.SpiderOptions
 import com.heledron.spideranimation.utilities.FORWARD_VECTOR
 import net.minecraft.world.level.block.Blocks
-import org.bukkit.util.Vector
+import net.minecraft.world.phys.Vec3
 
 
 private fun equalLength(segmentCount: Int, length: Double): List<SegmentPlan> {
     return List(segmentCount) { SegmentPlan(length, FORWARD_VECTOR) }
 }
 
-private fun BodyPlan.addLegPair(root: Vector, rest: Vector, segments: List<SegmentPlan>) {
-    legs += LegPlan(Vector( root.x, root.y, root.z), Vector( rest.x, rest.y, rest.z), segments)
-    legs += LegPlan(Vector(-root.x, root.y, root.z), Vector(-rest.x, rest.y, rest.z), segments.map { it.clone() })
+private fun BodyPlan.addLegPair(root: Vec3, rest: Vec3, segments: List<SegmentPlan>) {
+    legs += LegPlan(Vec3(root.x, root.y, root.z), Vec3(rest.x, rest.y, rest.z), segments)
+    legs += LegPlan(Vec3(-root.x, root.y, root.z), Vec3(-rest.x, rest.y, rest.z), segments.map { it.clone() })
 }
 
 fun biped(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
-    options.bodyPlan.addLegPair(Vector(.0, .0, .0), Vector(1.0, .0, .0), equalLength(segmentCount, 1.0 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0, .0, .0), Vec3(1.0, .0, .0), equalLength(segmentCount, 1.0 * segmentLength))
       applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 
 fun quadruped(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
-    options.bodyPlan.addLegPair(Vector(.0, .0, .0), Vector(0.9,.0, 0.9), equalLength(segmentCount, 0.9 * segmentLength))
-    options.bodyPlan.addLegPair(Vector(.0, .0, .0), Vector(1.0, .0, -1.1), equalLength(segmentCount, 1.2 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0, .0, .0), Vec3(0.9,.0, 0.9), equalLength(segmentCount, 0.9 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0, .0, .0), Vec3(1.0, .0, -1.1), equalLength(segmentCount, 1.2 * segmentLength))
       applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 
 fun hexapod(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
-    options.bodyPlan.addLegPair(Vector(.0,.0,0.1), Vector(1.0,.0, 1.1), equalLength(segmentCount, 1.1 * segmentLength))
-    options.bodyPlan.addLegPair(Vector(.0,.0,0.0), Vector(1.3,.0,-0.3), equalLength(segmentCount, 1.1 * segmentLength))
-    options.bodyPlan.addLegPair(Vector(.0,.0,-.1), Vector(1.2,.0,-2.0), equalLength(segmentCount, 1.6 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0,0.1), Vec3(1.0,.0, 1.1), equalLength(segmentCount, 1.1 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0,0.0), Vec3(1.3,.0,-0.3), equalLength(segmentCount, 1.1 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0,-.1), Vec3(1.2,.0,-2.0), equalLength(segmentCount, 1.6 * segmentLength))
       applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
 
 fun octopod(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
-    options.bodyPlan.addLegPair(Vector(.0,.0,  .1), Vector(1.0, .0,  1.6), equalLength(segmentCount, 1.1 * segmentLength))
-    options.bodyPlan.addLegPair(Vector(.0,.0,  .0), Vector(1.3, .0,  0.4), equalLength(segmentCount, 1.0 * segmentLength))
-    options.bodyPlan.addLegPair(Vector(.0,.0, -.1), Vector(1.3, .0, -0.9), equalLength(segmentCount, 1.1 * segmentLength))
-    options.bodyPlan.addLegPair(Vector(.0,.0, -.2), Vector(1.1, .0, -2.5), equalLength(segmentCount, 1.6 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0,  .1), Vec3(1.0, .0,  1.6), equalLength(segmentCount, 1.1 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0,  .0), Vec3(1.3, .0,  0.4), equalLength(segmentCount, 1.0 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0, -.1), Vec3(1.3, .0, -0.9), equalLength(segmentCount, 1.1 * segmentLength))
+    options.bodyPlan.addLegPair(Vec3(.0,.0, -.2), Vec3(1.1, .0, -2.5), equalLength(segmentCount, 1.6 * segmentLength))
       applyLineLegModel(options.bodyPlan, Blocks.NETHERITE_BLOCK.defaultBlockState())
     return options
 }
@@ -71,8 +71,8 @@ private fun createRobotSegments(segmentCount: Int, lengthScale: Double) = List(s
 fun quadBot(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
     options.bodyPlan.bodyModel = SpiderTorsoModels.FLAT.model.clone()
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15, .2), rest = Vector(1.3 * 1.0,.0, 1.0), createRobotSegments(segmentCount, .9 * .7 * segmentLength))
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15,-.2), rest = Vector(1.3 * 1.1,.0,-1.2), createRobotSegments(segmentCount, 1.2 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15, .2), rest = Vec3(1.3 * 1.0,.0, 1.0), createRobotSegments(segmentCount, .9 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15,-.2), rest = Vec3(1.3 * 1.1,.0,-1.2), createRobotSegments(segmentCount, 1.2 * .7 * segmentLength))
     applyMechanicalLegModel(options.bodyPlan)
     return options
 }
@@ -80,9 +80,9 @@ fun quadBot(segmentCount: Int, segmentLength: Double): SpiderOptions {
 fun hexBot(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
     options.bodyPlan.bodyModel = SpiderTorsoModels.FLAT.model.clone()
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15, .2), rest = Vector(1.3 * 1.0,.0, 1.3), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15, .0), rest = Vector(1.3 * 1.2,.0,-0.1), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15,-.2), rest = Vector(1.3 * 1.1,.0,-1.6), createRobotSegments(segmentCount, 1.3 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15, .2), rest = Vec3(1.3 * 1.0,.0, 1.3), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15, .0), rest = Vec3(1.3 * 1.2,.0,-0.1), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15,-.2), rest = Vec3(1.3 * 1.1,.0,-1.6), createRobotSegments(segmentCount, 1.3 * .7 * segmentLength))
     applyMechanicalLegModel(options.bodyPlan)
     return options
 }
@@ -90,10 +90,10 @@ fun hexBot(segmentCount: Int, segmentLength: Double): SpiderOptions {
 fun octoBot(segmentCount: Int, segmentLength: Double): SpiderOptions {
     val options = SpiderOptions()
     options.bodyPlan.bodyModel = SpiderTorsoModels.FLAT.model.clone()
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15, .3), rest = Vector(1.3 * 1.0,.0, 1.3), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15, .1), rest = Vector(1.3 * 1.2,.0, 0.5), createRobotSegments(segmentCount, 1.0 * .7 * segmentLength))
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15, .1), rest = Vector(1.3 * 1.2,.0,-0.7), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
-    options.bodyPlan.addLegPair(root = Vector(.2,-.2 - .15,-.3), rest = Vector(1.3 * 1.1,.0,-1.6), createRobotSegments(segmentCount, 1.3 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15, .3), rest = Vec3(1.3 * 1.0,.0, 1.3), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15, .1), rest = Vec3(1.3 * 1.2,.0, 0.5), createRobotSegments(segmentCount, 1.0 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15, .1), rest = Vec3(1.3 * 1.2,.0,-0.7), createRobotSegments(segmentCount, 1.1 * .7 * segmentLength))
+    options.bodyPlan.addLegPair(root = Vec3(.2,-.2 - .15,-.3), rest = Vec3(1.3 * 1.1,.0,-1.6), createRobotSegments(segmentCount, 1.3 * .7 * segmentLength))
     applyMechanicalLegModel(options.bodyPlan)
     return options
 }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/SpiderRenderer.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/SpiderRenderer.kt
@@ -8,7 +8,7 @@ import com.heledron.spideranimation.utilities.spawnParticle
 import org.bukkit.Color
 import org.bukkit.Location
 import org.bukkit.Particle
-import org.bukkit.util.Vector
+import net.minecraft.world.phys.Vec3
 import kotlin.random.Random
 
 class SpiderRenderer(val spider: Spider): SpiderComponent {
@@ -85,27 +85,28 @@ class SpiderParticleRenderer(val spider: Spider): SpiderComponent {
             for (leg in spider.body.legs) {
                 val world = leg.spider.world
                 val chain = leg.chain
-                var current = chain.root.toLocation(world)
+                var current = Location(world, chain.root.x, chain.root.y, chain.root.z)
 
                 for ((i, segment) in chain.segments.withIndex()) {
                     val thickness = (chain.segments.size - i - 1) * 0.025
                     renderLine(current, segment.position, thickness)
-                    current = segment.position.toLocation(world)
+                    current = Location(world, segment.position.x, segment.position.y, segment.position.z)
                 }
             }
         }
 
-        fun renderLine(point1: Location, point2: Vector, thickness: Double) {
+        fun renderLine(point1: Location, point2: Vec3, thickness: Double) {
             val gap = .05
 
-            val amount = point1.toVector().distance(point2) / gap
-            val step = point2.clone().subtract(point1.toVector()).multiply(1 / amount)
+            val startVec = Vec3(point1.x, point1.y, point1.z)
+            val amount = startVec.distanceTo(point2) / gap
+            val step = point2.subtract(startVec).scale(1 / amount)
 
             val current = point1.clone()
 
             for (i in 0..amount.toInt()) {
                 spawnParticle(Particle.BUBBLE, current, 1, thickness, thickness, thickness, 0.0)
-                current.add(step)
+                current.add(step.x, step.y, step.z)
             }
         }
     }

--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderDebugRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderDebugRenderEntities.kt
@@ -19,8 +19,8 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
         // Render scan bars
         if (spider.options.debug.scanBars) group.add("scanBar" to legIndex, lineRenderEntity(
             level = spider.world,
-            position = leg.scanStartPosition.toVec3(),
-            vector = leg.scanVector.toVec3(),
+            position = leg.scanStartPosition,
+            vector = leg.scanVector,
             thickness = .05f * scale,
             init = {
                 it.setBrightness(Brightness(15, 15))
@@ -34,7 +34,7 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
         // Render trigger zone
         if (spider.options.debug.triggerZones) group.add("triggerZoneVertical" to legIndex, blockRenderEntity(
             level = spider.world,
-            position = leg.triggerZone.center.toVec3(),
+            position = leg.triggerZone.center,
             init = {
                 it.setTeleportDuration(1)
                 it.setInterpolationDuration(1)
@@ -58,9 +58,9 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
         if (spider.options.debug.triggerZones) group.add("triggerZoneHorizontal" to legIndex, blockRenderEntity(
             level = spider.world,
             position = run {
-                val pos = leg.triggerZone.center.clone()
-                pos.y = leg.target.position.y.coerceIn(pos.y - leg.triggerZone.vertical, pos.y + leg.triggerZone.vertical)
-                pos.toVec3()
+                var pos = leg.triggerZone.center
+                pos = pos.setY(leg.target.position.y.coerceIn(pos.y - leg.triggerZone.vertical, pos.y + leg.triggerZone.vertical))
+                pos
             },
             init = {
                 it.setTeleportDuration(1)
@@ -85,7 +85,7 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
         // Render end effector
         if (spider.options.debug.endEffectors) group.add("endEffector" to legIndex, blockRenderEntity(
             level = spider.world,
-            position = leg.endEffector.toVec3(),
+            position = leg.endEffector,
             init = {
                 it.setTeleportDuration(1)
                 it.setBrightness(Brightness(15, 15))
@@ -105,7 +105,7 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
         // Render target position
         if (spider.options.debug.targetPositions) group.add("targetPosition" to legIndex, blockRenderEntity(
             level = spider.world,
-            position = leg.target.position.toVec3(),
+            position = leg.target.position,
             init = {
                 it.setTeleportDuration(1)
                 it.setBrightness(Brightness(15, 15))
@@ -185,8 +185,8 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
 
             group.add("polygon" to i, lineRenderEntity(
                 level = spider.world,
-                position = a.toVec3(),
-                vector = b.clone().subtract(a).toVec3(),
+                position = a,
+                vector = b.subtract(a),
                 thickness = .05f * scale,
                 interpolation = 0,
                 init = { it.setBrightness(Brightness(15, 15)) },
@@ -197,7 +197,7 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
 
     if (spider.options.debug.centreOfMass && normal.centreOfMass != null) group.add("centreOfMass", blockRenderEntity(
         level = spider.world,
-        position = normal.centreOfMass.toVec3(),
+        position = normal.centreOfMass,
         init = {
             it.setTeleportDuration(1)
             it.setBrightness(Brightness(15, 15))
@@ -214,8 +214,8 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
 
     if (spider.options.debug.normalForce && normal.centreOfMass != null && normal.origin !== null) group.add("acceleration", lineRenderEntity(
         level = spider.world,
-        position = normal.origin.toVec3(),
-        vector = normal.centreOfMass.clone().subtract(normal.origin).toVec3(),
+        position = normal.origin,
+        vector = normal.centreOfMass.subtract(normal.origin),
         thickness = .02f * scale,
         interpolation = 1,
         init = { it.setBrightness(Brightness(15, 15)) },

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/bukkitConversions.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/bukkitConversions.kt
@@ -1,8 +1,0 @@
-package com.heledron.spideranimation.utilities
-
-import net.minecraft.world.phys.Vec3
-import org.bukkit.util.Vector
-
-fun Vector.toVec3(): Vec3 = Vec3(this.x, this.y, this.z)
-
-fun Vec3.toVector(): Vector = Vector(this.x, this.y, this.z)

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/maths.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/maths.kt
@@ -60,6 +60,12 @@ fun Vector3f.toVec3(): Vec3 = Vec3(this.x.toDouble(), this.y.toDouble(), this.z.
 
 fun Vector3d.toVec3(): Vec3 = Vec3(this.x, this.y, this.z)
 
+fun Vec3.clone(): Vec3 = Vec3(this.x, this.y, this.z)
+
+fun Vec3.setY(value: Double): Vec3 = Vec3(this.x, value, this.z)
+
+val Vec3.isZero: Boolean get() = this.x == 0.0 && this.y == 0.0 && this.z == 0.0
+
 fun Vec3.rotateAroundY(angle: Double, origin: Vec3): Vec3 {
     val translated = this.subtract(origin)
     val sin = kotlin.math.sin(angle)


### PR DESCRIPTION
## Summary
- remove Bukkit Vector conversions and rely on Vec3 math helpers
- update spider mechanics, rendering, and items to use Vec3 directly
- ensure repository no longer imports `org.bukkit.util.Vector`

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching {languageVersion=17}...)*

------
https://chatgpt.com/codex/tasks/task_b_689ac84843788329b27b2d685e08deb6