### PR TITLE
Replace command teleport with API movement

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/Mountable.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/Mountable.kt
@@ -2,7 +2,10 @@ package com.heledron.spideranimation.spider.misc
 
 import com.heledron.spideranimation.spider.Spider
 import com.heledron.spideranimation.spider.SpiderComponent
-import com.heledron.spideranimation.utilities.*
+import com.heledron.spideranimation.utilities.RenderEntity
+import com.heledron.spideranimation.utilities.SingleEntityRenderer
+import com.heledron.spideranimation.utilities.onServerTick
+import com.heledron.spideranimation.utilities.playSound
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.sounds.SoundEvents
 import net.minecraft.world.InteractionHand
@@ -127,13 +130,11 @@ class Mountable(val spider: Spider): SpiderComponent {
                 it.setNoPhysics(true)
                 it.setMarker(true)
             },
-            update = update@{
+            update = update@{ markerEntity ->
                 if (getRider() == null) return@update
 
-                // This is the only way to preserve passengers when teleporting.
-                // Paper has a TeleportFlag, but it is not supported by Spigot.
-                // https://jd.papermc.io/paper/1.21/io/papermc/paper/entity/TeleportFlag.EntityState.html
-                runCommandSilently("execute as ${it.uuid} at @s run tp ${markerLocation.x} ${markerLocation.y} ${markerLocation.z}")
+                // absMoveTo preserves passengers when teleporting.
+                markerEntity.absMoveTo(markerLocation.x, markerLocation.y, markerLocation.z)
             }
         ))
     }


### PR DESCRIPTION
## Summary
- Reposition marker entity using `absMoveTo` to retain passengers
- Remove unused `runCommandSilently` and star imports

## Testing
- `./gradlew test` *(fails: Unable to access jarfile /workspace/minecraft-spider/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_689ba225a4dc8329809971bca75de2a0