### PR TITLE
Document Forge server setup and drop Bukkit references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
 # Spider
 ## Introduction
-This plugin was developed for a video series about procedural animations.
+This mod was developed for a video series about procedural animations.
 1. Procedural Walking Animation: https://youtu.be/Hc9x1e85L0w
 2. Procedural Galloping Animation: https://youtu.be/r70xJytj0sw
 3. Procedurally Animated Robots: https://youtu.be/PSnPOYeTW-0
 
 
-This plugin is very experimental and untested in multiplayer. Use at your own risk.
+This mod is very experimental and untested in multiplayer. Use at your own risk.
+
+The Spider Animation mod runs entirely on the server. Clients can join with vanilla Minecraft and do not need to download anything.
 
 
 
 ## Installation
 1. Download the JAR from the [releases page](https://github.com/TheCymaera/minecraft-spider/releases/).
-2. Set up a [Paper](https://papermc.io/downloads) or [Spigot](https://getbukkit.org/download/spigot) server. (Instructions below)
-3. Add the JAR to the `plugins` folder.
+2. Set up a [Forge](https://files.minecraftforge.net/) server for Minecraft **1.20.1** (instructions below).
+3. Place the JAR in the server's `mods` folder.
 4. Download the world folder from [Planet Minecraft](https://www.planetminecraft.com/project/spider-garden/).
 5. Place the world folder in the server directory. Name it `world`.
 
 ## Running a Server
-1. Download a server JAR from [Paper](https://papermc.io/downloads) or [Spigot](https://getbukkit.org/download/spigot).
-2. Run the following command `java -Xmx1024M -Xms1024M -jar server.jar nogui`.
-3. I typically use the Java runtime bundled with my Minecraft installation so as to avoid version conflicts.
-   - In Modrinth, you can find the Java runtime location inside the profile options menu.
-4. Accept the EULA by changing `eula=false` to `eula=true` in the `eula.txt` file.
+1. Download the Forge installer for Minecraft **1.20.1** and run it with the `--installServer` option.
+2. Accept the EULA by changing `eula=false` to `eula=true` in the generated `eula.txt` file.
+3. Run the server with a command similar to `java -Xmx4G -Xms4G -jar forge-1.20.1-47.3.0.jar nogui`.
+4. Place the Spider Animation JAR in the `mods` folder if you have not already.
 5. Join the server with `localhost` as the IP address.
 
 
@@ -112,13 +113,13 @@ Copy block examples used in the video:
 
 ## Development
 1. Clone or download the repo.
-2. Run Maven `package` to build the plugin. The resulting JAR will be in the `target` folder.
-3. For convenience, set up a symlink and add the link to the server `plugins` folder.
+2. Run `./gradlew build` to compile the mod. The resulting JAR will be in `build/libs`.
+3. For convenience, set up a symlink and add the link to the server `mods` folder.
    - Windows: `mklink /D newFile.jar originalFile.jar`
-   - Mac/Linux: `ln -s originalFile.jar newFile.jar `
+   - Mac/Linux: `ln -s originalFile.jar newFile.jar`
 
 ## License
-You may use the plugin and source code for both commercial or non-commercial purposes.
+You may use the mod and source code for both commercial or non-commercial purposes.
 
 Attribution is appreciated but not due.
 

--- a/src/main/kotlin/com/heledron/spideranimation/AppState.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/AppState.kt
@@ -37,8 +37,8 @@ object AppState {
     /**
      * Creates a new [Spider] in the given [level] at the specified [position].
      *
-     * Using [ServerLevel] and [Vec3] keeps this API in terms of native Minecraft
-     * types instead of Bukkit wrappers. The supplied [position] should represent
+     * Using [ServerLevel] and [Vec3] keeps this API in terms of native Minecraft/
+     * Forge types without relying on external server wrappers. The supplied [position] should represent
      * the ground location for the spider; this method adds the configured body
      * height so the spider's body rests above the terrain.
      *

--- a/src/main/kotlin/com/heledron/spideranimation/RegisterCommands.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/RegisterCommands.kt
@@ -14,10 +14,8 @@ import net.minecraft.network.chat.Component
 import net.minecraftforge.event.RegisterCommandsEvent
 
 /**
- * Registers Brigadier command trees for the mod.  This replaces the previous
- * Bukkit style registration which relied on CommandSender and Player.  The
- * commands are now registered during [RegisterCommandsEvent] and operate using
- * [CommandSourceStack].
+ * Registers Brigadier command trees for the mod using Forge's
+ * [RegisterCommandsEvent]. Commands operate using [CommandSourceStack].
  */
 fun registerCommands(event: RegisterCommandsEvent) {
     val dispatcher: CommandDispatcher<CommandSourceStack> = event.dispatcher

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
@@ -75,8 +75,8 @@ class SpiderAnimationMod {
         val target = if (AppState.miscOptions.showLaser) AppState.target else null
         if (target != null) {
             // TODO: restore target rendering once a Vec3-based renderer is available.
-            // The previous renderer relied on Bukkit's Location type and was removed during
-            // the Vec3 migration, so no marker is drawn until a replacement exists.
+            // The previous implementation used a Location type from another server API;
+            // a Forge-friendly Vec3 renderer has not yet been written, so no marker is drawn.
         }
 
         AppState.chainVisualizer?.render()

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderConfig.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderConfig.kt
@@ -7,9 +7,8 @@ import net.minecraftforge.fml.config.ModConfig
 import net.minecraftforge.fml.event.config.ModConfigEvent
 
 /**
- * Forge configuration for the Spider Animation mod.  This replaces the
- * previous Bukkit based configuration by persisting options in a standard
- * Forge config file.
+ * Forge configuration for the Spider Animation mod, persisting options in a
+ * standard Forge config file.
  */
 object SpiderConfig {
     private val builder = ForgeConfigSpec.Builder()

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/RGB.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/RGB.kt
@@ -5,7 +5,7 @@ import kotlin.math.pow
 import kotlin.math.sqrt
 
 /**
- * Simple RGB container used instead of Bukkit's [org.bukkit.Color].
+ * Simple RGB container used instead of the limited [net.minecraft.world.item.DyeColor] palette.
  */
 data class RGB(val r: Int, val g: Int, val b: Int) {
     /** Scale the colour to the provided Minecraft brightness level (0-15). */


### PR DESCRIPTION
## Summary
- rewrite README for Forge 1.20.1 servers and note the mod is server-only
- replace Bukkit mentions with Forge equivalents in code comments

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 gradle -Dnet.minecraftforge.gradle.check.certs=false test` *(failed: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_b_689bcda5ca688329951582a3eb63f461