### PR TITLE
Remove obsolete transitionSegmentBlock block

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/misc/Cloak.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/misc/Cloak.kt
@@ -150,23 +150,4 @@ class Cloak(var  spider: Spider) : SpiderComponent {
             cloakGlitching = false
         }
     }
-
-
-//    val transitioning = ArrayList<Any>()
-//    fun transitionSegmentBlock(id: Any, waitTime: Int, glitchTime: Int, newBlock: Material?) {
-//        if (transitioning.contains(id)) return
-//        transitioning.add(id)
-//
-//        val scheduler = SeriesScheduler()
-//        scheduler.sleep(waitTime.toLong())
-//        scheduler.run {
-//            cloakOverride[id] = Material.GRAY_GLAZED_TERRACOTTA.createBlockData()
-//        }
-//
-//        scheduler.sleep(glitchTime.toLong())
-//        scheduler.run {
-//            cloakColor[id] = newBlock
-//            transitioning.remove(id)
-//        }
-//    }
 }


### PR DESCRIPTION
## Summary
- delete unused `transitionSegmentBlock` legacy code in `Cloak`

## Testing
- `gradle test` *(fails: Cannot find Java installation matching toolchain requirements)*

------
https://chatgpt.com/codex/tasks/task_b_689bd3bdf8648329a3d7ab0c3baa4b7d