### PR TITLE
Remove client run target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,16 +19,6 @@ minecraft {
     mappings("official", "1.20.1")
 
     runs {
-        create("client") {
-            workingDirectory(project.file("run"))
-            property("forge.logging.markers", "REGISTRIES")
-            property("forge.logging.console.level", "debug")
-            mods {
-                create("spideranimation") {
-                    source(sourceSets.main.get())
-                }
-            }
-        }
         create("server") {
             workingDirectory(project.file("run"))
             property("forge.logging.markers", "REGISTRIES")


### PR DESCRIPTION
## Summary
- remove the unused `client` run configuration from the Gradle build script

## Testing
- `gradle build` *(fails: Starting a Gradle Daemon (subsequent builds will be faster))*

------
https://chatgpt.com/codex/tasks/task_b_689bf7f799188329881f4603b10650db