### PR TITLE
Render target marker

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
@@ -3,6 +3,8 @@ package com.heledron.spideranimation
 import com.heledron.spideranimation.kinematic_chain_visualizer.KinematicChainVisualizer
 import com.heledron.spideranimation.spider.misc.StayStillBehaviour
 import com.heledron.spideranimation.utilities.AppState
+import com.heledron.spideranimation.utilities.RenderEntityGroup
+import com.heledron.spideranimation.utilities.vec3MarkerRenderEntity
 import com.heledron.spideranimation.ModItems
 import com.heledron.spideranimation.registerCommands
 import net.minecraftforge.common.MinecraftForge
@@ -74,9 +76,11 @@ class SpiderAnimationMod {
         // Render target marker if one is set
         val target = if (AppState.miscOptions.showLaser) AppState.target else null
         if (target != null) {
-            // TODO: restore target rendering once a Vec3-based renderer is available.
-            // The previous implementation used a Location type from another server API;
-            // a Forge-friendly Vec3 renderer has not yet been written, so no marker is drawn.
+            val level = event.server.overworld()
+            val group = RenderEntityGroup().apply {
+                add(0, vec3MarkerRenderEntity(level, target))
+            }
+            AppState.renderer.render("target", group)
         }
 
         AppState.chainVisualizer?.render()

--- a/src/main/kotlin/com/heledron/spideranimation/utilities/EntityRenderer.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/EntityRenderer.kt
@@ -7,6 +7,7 @@ import net.minecraft.world.entity.Display.TextDisplay
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.level.Level
+import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.phys.Vec3
 import org.joml.Matrix4f
 import java.io.Closeable
@@ -110,6 +111,22 @@ fun textRenderEntity(
     update = {
         it.setText(Component.literal(text))
         update(it)
+    },
+)
+
+/** Create a simple marker [BlockDisplay] at the given [position]. */
+fun vec3MarkerRenderEntity(
+    level: Level,
+    position: Vec3,
+) = blockRenderEntity(
+    level = level,
+    position = position,
+    init = {
+        it.blockState = Blocks.REDSTONE_BLOCK.defaultBlockState()
+        it.setTeleportDuration(1)
+        it.setInterpolationDuration(1)
+        it.setBrightness(Brightness(15, 15))
+        it.transformation = centredTransform(.25f, .25f, .25f)
     },
 )
 


### PR DESCRIPTION
## Summary
- Add `vec3MarkerRenderEntity` helper for displaying a small red block marker at a Vec3
- Render target markers during server ticks when a target is provided

## Testing
- ⚠️ `./gradlew test` *(fails: Unable to access jarfile gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_b_689c0c5d1f248329a9ed61d1bce903b2