### PR TITLE
Remove redundant contactPolygon mapping

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderDebugRenderEntities.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/rendering/spiderDebugRenderEntities.kt
@@ -178,7 +178,7 @@ fun spiderDebugRenderEntities(spider: Spider): RenderEntityGroup {
 
     val normal = spider.body.normal ?: return group
     if (spider.options.debug.legPolygons && normal.contactPolygon != null) {
-        val points = normal.contactPolygon//.map { it.toLocation(spider.world)}
+        val points = normal.contactPolygon
         for (i in points.indices) {
             val a = points[i]
             val b = points[(i + 1) % points.size]


### PR DESCRIPTION
## Summary
- drop obsolete `.map { it.toLocation(spider.world) }` from debug renderer

## Testing
- `gradle test` *(fails: Cannot find a Java installation on your machine (languageVersion=17))*

------
https://chatgpt.com/codex/tasks/task_b_689c1060c0cc832982cd83d64c5d2ff9