### PR TITLE
Remove unused stabilization factor

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/spider/body/SpiderBody.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/body/SpiderBody.kt
@@ -139,7 +139,7 @@ class SpiderBody(val spider: Spider): SpiderComponent {
                 origin = origin,
                 centreOfMass = centreOfMass,
                 contactPolygon = legsPolygon
-            ).apply { applyStabilization(this) }
+            )
         }
 
         val polygon2D = legsPolygon.map { Vector2d(it.x, it.z) }
@@ -160,23 +160,7 @@ class SpiderBody(val spider: Spider): SpiderComponent {
             origin = origin,
             centreOfMass = centreOfMass,
             contactPolygon = legsPolygon
-        ).apply { applyStabilization(this )}
-    }
-
-    private fun applyStabilization(normal: NormalInfo) {
-        if (normal.origin == null) return
-        if (normal.centreOfMass == null) return
-
-        val origin = normal.origin!!
-        val centre = normal.centreOfMass!!
-        if (origin.horizontalDistance(centre) < spider.gait.polygonLeeway) {
-            normal.origin = Vec3(centre.x, origin.y, centre.z)
-        }
-
-        val stabilizationTarget = origin.setY(centre.y)
-        normal.centreOfMass = centre.lerp(stabilizationTarget, spider.gait.stabilizationFactor)
-
-        normal.normal = normal.centreOfMass!!.subtract(normal.origin!!).normalize()
+        )
     }
 }
 

--- a/src/main/kotlin/com/heledron/spideranimation/spider/configuration/Gait.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/spider/configuration/Gait.kt
@@ -45,7 +45,6 @@ class Gait(
             uncomfortableSpeedMultiplier = .6
             samePairCooldown = 2
             crossPairCooldown = 4
-            polygonLeeway = .5
         }
     }
 
@@ -107,10 +106,6 @@ class Gait(
     var crossPairCooldown = 1
 
     var useLegacyNormalForce = false
-    var polygonLeeway = .0
-    
-    // TODO: Consider removing this
-    var stabilizationFactor = .0 //0.7
 
     var uncomfortableSpeedMultiplier = 0.0
 


### PR DESCRIPTION
## Summary
- remove unused stabilization factor and polygon leeway settings from gait configuration
- drop stabilization logic from spider body normal calculations

## Testing
- `gradle build` *(fails: Failed to validate certificate for host 'https://maven.minecraftforge.net/' and cannot resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_689c117e4f908329ac7c39c831e21dc9