### PR TITLE
Allow vanilla clients by ignoring display test

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,6 +5,7 @@ license="MIT"
 modId="spideranimation"
 version="3.0"
 displayName="Spider Animation"
+displayTest="IGNORE_ALL_VERSION"
 credits=""
 authors="Heledron"
 description='''


### PR DESCRIPTION
## Summary
- Allow vanilla clients to join by ignoring mod version checking in `mods.toml`

## Testing
- `gradle build --console=plain --no-daemon` *(fails: Cannot find a Java installation matching {languageVersion=17})*

------
https://chatgpt.com/codex/tasks/task_b_689d69d772bc83298d873642ec4198b2