### PR TITLE
chore: centralize version property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
     id("net.minecraftforge.gradle") version "[6.0,6.2)"
 }
 
+val modVersion: String by project
+
 group = "com.heledron"
-version = "3.0-SNAPSHOT"
+version = modVersion
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(17))
@@ -55,6 +57,13 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.processResources {
+    inputs.property("version", modVersion)
+    filesMatching("META-INF/mods.toml") {
+        expand("version" to modVersion)
+    }
 }
 
 sourceSets.main.get().resources.srcDir("src/generated/resources")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@
 org.gradle.jvmargs=-Xmx3G
 kotlin.code.style=official
 org.gradle.java.installations.auto-download=true
+modVersion=3.0

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@ loaderVersion="[47,)"
 license="MIT"
 [[mods]]
 modId="spideranimation"
-version="3.0"
+version="${version}"
 displayName="Spider Animation"
 displayTest="IGNORE_ALL_VERSION"
 credits=""


### PR DESCRIPTION
## Summary
- define single mod version in `gradle.properties`
- reference property in build script and expand into `mods.toml`

## Testing
- `gradle test` *(fails: missing Java 17 toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_689d6be74d088329a3a976e8c030c067