### PR TITLE
Use vanilla items for control tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ The Spider Animation mod runs entirely on the server. Clients can join with vani
 ## Commands
 Autocomplete will show available options.
 
-Get control items:
+Get placeholder control tools (vanilla items with custom names):
 ```
 /items
 ```
+These tools use existing vanilla items (sticks, shears, etc.) to control the spider.
 
 Load preset:
 ```

--- a/src/main/kotlin/com/heledron/spideranimation/ControlItemEvents.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ControlItemEvents.kt
@@ -1,0 +1,150 @@
+package com.heledron.spideranimation
+
+import com.heledron.spideranimation.spider.misc.DirectionBehaviour
+import com.heledron.spideranimation.spider.misc.TargetBehaviour
+import com.heledron.spideranimation.spider.rendering.SpiderParticleRenderer
+import com.heledron.spideranimation.spider.rendering.SpiderRenderer
+import com.heledron.spideranimation.utilities.AppState
+import com.heledron.spideranimation.utilities.raycastGround
+import net.minecraft.network.chat.Component
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.sounds.SoundEvents
+import net.minecraft.sounds.SoundSource
+import net.minecraft.world.InteractionResult
+import net.minecraft.world.phys.Vec3
+import net.minecraftforge.event.TickEvent
+import net.minecraftforge.event.entity.player.PlayerInteractEvent
+import net.minecraftforge.eventbus.api.SubscribeEvent
+import kotlin.math.roundToInt
+
+/**
+ * Handles interactions with control items using Forge events.
+ */
+object ControlItemEvents {
+    @SubscribeEvent
+    fun onRightClick(event: PlayerInteractEvent.RightClickItem) {
+        val player = event.entity
+        val level = player.level()
+        if (level.isClientSide) return
+        val serverPlayer = player as? ServerPlayer ?: return
+        val tool = event.itemStack.getControlItem() ?: return
+        when (tool) {
+            ControlItem.SPIDER -> {
+                val spider = AppState.spider
+                if (spider == null) {
+                    val yawIncrements = 45.0f
+                    val yaw = serverPlayer.yHeadRot
+                    val yawRounded = (yaw / yawIncrements).roundToInt() * yawIncrements
+                    val eye = serverPlayer.eyePosition
+                    val result = level.raycastGround(eye, serverPlayer.lookAngle, 100.0) ?: return
+                    val hit = result.location
+                    val orientation = org.joml.Quaternionf().rotateY(Math.toRadians(yawRounded.toDouble()).toFloat())
+                    level.playSound(null, hit.x, hit.y, hit.z, SoundEvents.NETHERITE_BLOCK_PLACE, SoundSource.BLOCKS, 1.0f, 1.0f)
+                    AppState.createSpider(level as ServerLevel, hit, orientation)
+                    serverPlayer.displayClientMessage(Component.literal("Spider created"), true)
+                } else {
+                    level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.ITEM_FRAME_REMOVE_ITEM, SoundSource.BLOCKS, 1.0f, 0.0f)
+                    AppState.spider = null
+                    serverPlayer.displayClientMessage(Component.literal("Spider removed"), true)
+                }
+            }
+            ControlItem.DISABLE_LEG -> {
+                val selectedLeg = AppState.spider?.pointDetector?.selectedLeg
+                if (selectedLeg == null) {
+                    level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
+                } else {
+                    selectedLeg.isDisabled = !selectedLeg.isDisabled
+                    level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.LANTERN_PLACE, SoundSource.BLOCKS, 1.0f, 1.0f)
+                }
+            }
+            ControlItem.TOGGLE_DEBUG -> {
+                AppState.showDebugVisuals = !AppState.showDebugVisuals
+                SpiderConfig.SHOW_DEBUG.set(AppState.showDebugVisuals)
+                SpiderConfig.save()
+                AppState.chainVisualizer?.detailed = AppState.showDebugVisuals
+                val pitch = if (AppState.showDebugVisuals) 2.0f else 1.5f
+                level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, pitch)
+            }
+            ControlItem.SWITCH_RENDERER -> {
+                val spider = AppState.spider ?: return
+                spider.renderer = if (spider.renderer is SpiderRenderer) {
+                    level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.AXOLOTL_ATTACK, SoundSource.BLOCKS, 1.0f, 1.0f)
+                    SpiderParticleRenderer(spider)
+                } else {
+                    level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.ARMOR_EQUIP_NETHERITE, SoundSource.BLOCKS, 1.0f, 1.0f)
+                    SpiderRenderer(spider)
+                }
+            }
+            ControlItem.TOGGLE_CLOAK -> {
+                AppState.spider?.cloak?.toggleCloak()
+            }
+            ControlItem.CHAIN_VIS_STEP -> {
+                val chain = AppState.chainVisualizer ?: return
+                level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
+                chain.step()
+            }
+            ControlItem.CHAIN_VIS_STRAIGHTEN -> {
+                val chain = AppState.chainVisualizer ?: return
+                val target = chain.target ?: return
+                level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
+                chain.straighten(target)
+            }
+            ControlItem.SWITCH_GAIT -> {
+                level.playSound(null, serverPlayer.x, serverPlayer.y, serverPlayer.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
+                AppState.gallop = !AppState.gallop
+                SpiderConfig.GALLOP.set(AppState.gallop)
+                SpiderConfig.save()
+                val message = if (!AppState.gallop) "Walk mode" else "Gallop mode"
+                serverPlayer.displayClientMessage(Component.literal(message), true)
+            }
+            ControlItem.LASER_POINTER, ControlItem.COME_HERE -> return
+        }
+        event.cancellationResult = InteractionResult.SUCCESS
+        event.isCanceled = true
+    }
+
+    @SubscribeEvent
+    fun onPlayerTick(event: TickEvent.PlayerTickEvent) {
+        if (event.phase != TickEvent.Phase.END) return
+        val player = event.player
+        if (player.level().isClientSide) return
+        val serverPlayer = player as? ServerPlayer ?: return
+        for (stack in listOf(serverPlayer.mainHandItem, serverPlayer.offhandItem)) {
+            when (stack.getControlItem()) {
+                ControlItem.DISABLE_LEG -> {
+                    AppState.spider?.pointDetector?.player = serverPlayer
+                }
+                ControlItem.LASER_POINTER -> {
+                    val eye = serverPlayer.eyePosition
+                    val directionVec = serverPlayer.lookAngle
+                    val result = player.level().raycastGround(eye, directionVec, 100.0)
+                    if (result == null) {
+                        val direction = Vec3(directionVec.x, 0.0, directionVec.z).normalize()
+                        AppState.spider?.let { it.behaviour = DirectionBehaviour(it, direction, direction) }
+                        AppState.chainVisualizer?.let {
+                            it.target = null
+                            it.resetIterator()
+                        }
+                    } else {
+                        val targetVal = result.location
+                        AppState.target = targetVal
+                        AppState.chainVisualizer?.let {
+                            it.target = targetVal
+                            it.resetIterator()
+                        }
+                        AppState.spider?.let { it.behaviour = TargetBehaviour(it, targetVal, it.lerpedGait.bodyHeight) }
+                    }
+                }
+                ControlItem.COME_HERE -> {
+                    AppState.spider?.let {
+                        val height = if (it.gait.straightenLegs) it.lerpedGait.bodyHeight * 2.0 else it.lerpedGait.bodyHeight * 5.0
+                        val eye = serverPlayer.eyePosition
+                        it.behaviour = TargetBehaviour(it, Vec3(eye.x, eye.y, eye.z), height)
+                    }
+                }
+                else -> {}
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/ModItems.kt
@@ -1,191 +1,40 @@
 package com.heledron.spideranimation
 
-import com.heledron.spideranimation.utilities.*
-import com.heledron.spideranimation.spider.misc.*
-import com.heledron.spideranimation.spider.rendering.*
-import net.minecraft.world.InteractionHand
-import net.minecraft.world.InteractionResultHolder
-import net.minecraft.world.entity.Entity
-import net.minecraft.server.level.ServerLevel
-import net.minecraft.server.level.ServerPlayer
+import net.minecraft.network.chat.Component
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.Level
-import net.minecraft.world.phys.Vec3
-import net.minecraft.sounds.SoundEvents
-import net.minecraft.sounds.SoundSource
-import net.minecraft.network.chat.Component
-import net.minecraftforge.registries.DeferredRegister
-import net.minecraftforge.registries.ForgeRegistries
-import net.minecraftforge.registries.RegistryObject
-import kotlin.math.roundToInt
+import net.minecraft.world.item.Items
 
-object ModItems {
-    val ITEMS: DeferredRegister<Item> = DeferredRegister.create(ForgeRegistries.ITEMS, SpiderAnimationMod.MOD_ID)
+/**
+ * Enumeration of control tools using existing vanilla items.
+ * Each item stack carries a small NBT tag to identify its role.
+ */
+enum class ControlItem(val item: Item, val tag: String, val displayName: String) {
+    SPIDER(Items.STICK, "spider", "Spawn/Remove Spider"),
+    DISABLE_LEG(Items.SHEARS, "disable_leg", "Disable Selected Leg"),
+    TOGGLE_DEBUG(Items.REDSTONE, "toggle_debug", "Toggle Debug Visuals"),
+    SWITCH_RENDERER(Items.BLAZE_ROD, "switch_renderer", "Switch Renderer"),
+    TOGGLE_CLOAK(Items.ENDER_PEARL, "toggle_cloak", "Toggle Cloak"),
+    CHAIN_VIS_STEP(Items.FEATHER, "chain_vis_step", "Chain Step"),
+    CHAIN_VIS_STRAIGHTEN(Items.BONE, "chain_vis_straighten", "Chain Straighten"),
+    SWITCH_GAIT(Items.SADDLE, "switch_gait", "Switch Gait"),
+    LASER_POINTER(Items.CARROT_ON_A_STICK, "laser_pointer", "Laser Pointer"),
+    COME_HERE(Items.LEAD, "come_here", "Come Here");
 
-    val SPIDER: RegistryObject<Item> = ITEMS.register("spider") { SpiderItem(Item.Properties()) }
-    val DISABLE_LEG: RegistryObject<Item> = ITEMS.register("disable_leg") { DisableLegItem(Item.Properties()) }
-    val TOGGLE_DEBUG: RegistryObject<Item> = ITEMS.register("toggle_debug") { ToggleDebugItem(Item.Properties()) }
-    val SWITCH_RENDERER: RegistryObject<Item> = ITEMS.register("switch_renderer") { SwitchRendererItem(Item.Properties()) }
-    val TOGGLE_CLOAK: RegistryObject<Item> = ITEMS.register("toggle_cloak") { ToggleCloakItem(Item.Properties()) }
-    val CHAIN_VIS_STEP: RegistryObject<Item> = ITEMS.register("chain_vis_step") { ChainVisStepItem(Item.Properties()) }
-    val CHAIN_VIS_STRAIGHTEN: RegistryObject<Item> = ITEMS.register("chain_vis_straighten") { ChainVisStraightenItem(Item.Properties()) }
-    val SWITCH_GAIT: RegistryObject<Item> = ITEMS.register("switch_gait") { SwitchGaitItem(Item.Properties()) }
-    val LASER_POINTER: RegistryObject<Item> = ITEMS.register("laser_pointer") { LaserPointerItem(Item.Properties()) }
-    val COME_HERE: RegistryObject<Item> = ITEMS.register("come_here") { ComeHereItem(Item.Properties()) }
-}
+    companion object {
+        const val TAG_KEY = "SpiderTool"
+    }
 
-class SpiderItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val spider = AppState.spider
-        if (spider == null) {
-            val yawIncrements = 45.0f
-            val yaw = player.yHeadRot
-            val yawRounded = (yaw / yawIncrements).roundToInt() * yawIncrements
-            val eye = player.eyePosition
-            val result = level.raycastGround(eye, player.lookAngle, 100.0)
-                ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-            val hit = result.location
-            val orientation = org.joml.Quaternionf().rotateY(Math.toRadians(yawRounded.toDouble()).toFloat())
-            level.playSound(null, hit.x, hit.y, hit.z, SoundEvents.NETHERITE_BLOCK_PLACE, SoundSource.BLOCKS, 1.0f, 1.0f)
-            AppState.createSpider(level as ServerLevel, hit, orientation)
-            player.displayClientMessage(Component.literal("Spider created"), true)
-        } else {
-            level.playSound(null, player.x, player.y, player.z, SoundEvents.ITEM_FRAME_REMOVE_ITEM, SoundSource.BLOCKS, 1.0f, 0.0f)
-            AppState.spider = null
-            player.displayClientMessage(Component.literal("Spider removed"), true)
+    /** Create an [ItemStack] representing this control tool. */
+    fun createStack(): ItemStack =
+        ItemStack(item).apply {
+            orCreateTag.putString(TAG_KEY, tag)
+            setHoverName(Component.literal(displayName))
         }
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
 }
 
-class DisableLegItem(properties: Properties) : Item(properties) {
-    override fun inventoryTick(stack: ItemStack, level: Level, entity: Entity, slot: Int, selected: Boolean) {
-        if (level.isClientSide) return
-        if (entity is ServerPlayer && (entity.mainHandItem == stack || entity.offhandItem == stack)) {
-            AppState.spider?.pointDetector?.player = entity
-        }
-    }
-
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val selectedLeg = AppState.spider?.pointDetector?.selectedLeg
-        if (selectedLeg == null) {
-            level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
-            return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-        }
-        selectedLeg.isDisabled = !selectedLeg.isDisabled
-        level.playSound(null, player.x, player.y, player.z, SoundEvents.LANTERN_PLACE, SoundSource.BLOCKS, 1.0f, 1.0f)
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class ToggleDebugItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        AppState.showDebugVisuals = !AppState.showDebugVisuals
-        SpiderConfig.SHOW_DEBUG.set(AppState.showDebugVisuals)
-        SpiderConfig.save()
-        AppState.chainVisualizer?.detailed = AppState.showDebugVisuals
-        val pitch = if (AppState.showDebugVisuals) 2.0f else 1.5f
-        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, pitch)
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class SwitchRendererItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val spider = AppState.spider ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        spider.renderer = if (spider.renderer is SpiderRenderer) {
-            level.playSound(null, player.x, player.y, player.z, SoundEvents.AXOLOTL_ATTACK, SoundSource.BLOCKS, 1.0f, 1.0f)
-            SpiderParticleRenderer(spider)
-        } else {
-            level.playSound(null, player.x, player.y, player.z, SoundEvents.ARMOR_EQUIP_NETHERITE, SoundSource.BLOCKS, 1.0f, 1.0f)
-            SpiderRenderer(spider)
-        }
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class ToggleCloakItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        AppState.spider?.cloak?.toggleCloak()
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class ChainVisStepItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
-        chain.step()
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class ChainVisStraightenItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        val chain = AppState.chainVisualizer ?: return InteractionResultHolder.pass(player.getItemInHand(hand))
-        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
-        chain.straighten(chain.target ?: return InteractionResultHolder.pass(player.getItemInHand(hand)))
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class SwitchGaitItem(properties: Properties) : Item(properties) {
-    override fun use(level: Level, player: ServerPlayer, hand: InteractionHand): InteractionResultHolder<ItemStack> {
-        if (level.isClientSide) return InteractionResultHolder.pass(player.getItemInHand(hand))
-        level.playSound(null, player.x, player.y, player.z, SoundEvents.DISPENSER_FAIL, SoundSource.BLOCKS, 1.0f, 2.0f)
-        AppState.gallop = !AppState.gallop
-        SpiderConfig.GALLOP.set(AppState.gallop)
-        SpiderConfig.save()
-        val message = if (!AppState.gallop) "Walk mode" else "Gallop mode"
-        player.displayClientMessage(Component.literal(message), true)
-        return InteractionResultHolder.sidedSuccess(player.getItemInHand(hand), level.isClientSide)
-    }
-}
-
-class LaserPointerItem(properties: Properties) : Item(properties) {
-    override fun inventoryTick(stack: ItemStack, level: Level, entity: Entity, slot: Int, selected: Boolean) {
-        if (level.isClientSide) return
-        if (entity is ServerPlayer && (entity.mainHandItem == stack || entity.offhandItem == stack)) {
-            val eye = entity.eyePosition
-            val directionVec = entity.lookAngle
-            val result = level.raycastGround(eye, directionVec, 100.0)
-            if (result == null) {
-                val direction = Vec3(directionVec.x, 0.0, directionVec.z).normalize()
-                AppState.spider?.let { it.behaviour = DirectionBehaviour(it, direction, direction) }
-                AppState.chainVisualizer?.let {
-                    it.target = null
-                    it.resetIterator()
-                }
-            } else {
-                val targetVal = result.location
-                AppState.target = targetVal
-                AppState.chainVisualizer?.let {
-                    it.target = targetVal
-                    it.resetIterator()
-                }
-                AppState.spider?.let { it.behaviour = TargetBehaviour(it, targetVal, it.lerpedGait.bodyHeight) }
-            }
-        }
-    }
-}
-
-class ComeHereItem(properties: Properties) : Item(properties) {
-    override fun inventoryTick(stack: ItemStack, level: Level, entity: Entity, slot: Int, selected: Boolean) {
-        if (level.isClientSide) return
-        if (entity is ServerPlayer && (entity.mainHandItem == stack || entity.offhandItem == stack)) {
-            AppState.spider?.let {
-                val height = if (it.gait.straightenLegs) it.lerpedGait.bodyHeight * 2.0 else it.lerpedGait.bodyHeight * 5.0
-                val eye = entity.eyePosition
-                it.behaviour = TargetBehaviour(it, Vec3(eye.x, eye.y, eye.z), height)
-            }
-        }
-    }
+/** Retrieve the [ControlItem] represented by this [ItemStack], if any. */
+fun ItemStack.getControlItem(): ControlItem? {
+    val tag = tag?.getString(ControlItem.TAG_KEY) ?: return null
+    return ControlItem.entries.firstOrNull { it.tag == tag }
 }

--- a/src/main/kotlin/com/heledron/spideranimation/RegisterCommands.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/RegisterCommands.kt
@@ -3,6 +3,7 @@ package com.heledron.spideranimation
 import com.heledron.spideranimation.spider.misc.splay
 import com.heledron.spideranimation.spider.presets.*
 import com.heledron.spideranimation.utilities.runLater
+import com.heledron.spideranimation.ControlItem
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.DoubleArgumentType
 import com.mojang.brigadier.arguments.IntegerArgumentType
@@ -20,10 +21,29 @@ import net.minecraftforge.event.RegisterCommandsEvent
 fun registerCommands(event: RegisterCommandsEvent) {
     val dispatcher: CommandDispatcher<CommandSourceStack> = event.dispatcher
 
+    registerItems(dispatcher)
     registerScale(dispatcher)
     registerPreset(dispatcher)
     registerFall(dispatcher)
     registerSplay(dispatcher)
+}
+
+private fun registerItems(dispatcher: CommandDispatcher<CommandSourceStack>) {
+    dispatcher.register(
+        Commands.literal("items")
+            .requires { it.hasPermission(2) }
+            .executes { ctx ->
+                val player = ctx.source.playerOrException
+                for (tool in ControlItem.entries) {
+                    val stack = tool.createStack()
+                    if (!player.addItem(stack)) {
+                        player.drop(stack, false)
+                    }
+                }
+                ctx.source.sendSuccess({ Component.literal("Gave control items") }, false)
+                1
+            }
+    )
 }
 
 private fun registerScale(dispatcher: CommandDispatcher<CommandSourceStack>) {

--- a/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/SpiderAnimationMod.kt
@@ -5,7 +5,6 @@ import com.heledron.spideranimation.spider.misc.StayStillBehaviour
 import com.heledron.spideranimation.utilities.AppState
 import com.heledron.spideranimation.utilities.RenderEntityGroup
 import com.heledron.spideranimation.utilities.vec3MarkerRenderEntity
-import com.heledron.spideranimation.ModItems
 import com.heledron.spideranimation.registerCommands
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.event.RegisterCommandsEvent
@@ -30,8 +29,8 @@ class SpiderAnimationMod {
         val bus = FMLJavaModLoadingContext.get().modEventBus
         bus.addListener(this::commonSetup)
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, SpiderConfig.SPEC)
-        ModItems.ITEMS.register(bus)
         MinecraftForge.EVENT_BUS.register(this)
+        MinecraftForge.EVENT_BUS.register(ControlItemEvents)
     }
 
     private val closeables = mutableListOf<Closeable>()


### PR DESCRIPTION
## Summary
- Replace custom item registrations with vanilla item placeholders marked by NBT tags
- Handle control tool interactions with Forge event handlers
- Add `/items` command and update docs to distribute new placeholders

## Testing
- `gradle build` *(fails: Cannot resolve external dependency net.minecraftforge:ForgeAutoRenamingTool:1.0.6 because no repositories are defined)*

------
https://chatgpt.com/codex/tasks/task_b_689d6f4c32988329a1e45ddd537a6b48