### PR TITLE
Add Gson dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ repositories {
 dependencies {
     minecraft("net.minecraftforge:forge:1.20.1-47.3.0")
     implementation(kotlin("stdlib"))
+    implementation("com.google.code.gson:gson:2.10.1")
     testImplementation(kotlin("test"))
 }
 


### PR DESCRIPTION
## Summary
- add Google's Gson as an implementation dependency

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_b_689e48fb8e588329af0f3c8c3e607908