### PR TITLE
Use JUnit 5 test dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     minecraft("net.minecraftforge:forge:1.20.1-47.3.0")
     implementation(kotlin("stdlib"))
     implementation("com.google.code.gson:gson:2.10.1")
-    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit5"))
 }
 
 tasks.test {


### PR DESCRIPTION
## Summary
- use the Kotlin JUnit 5 test dependency

## Testing
- `gradle test --console=plain -Dnet.minecraftforge.gradle.check.certs=false` *(fails: Could not resolve dependencies; the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_b_689e4fa4e2e483299e815c4ab47c257e