### PR TITLE
Specify ForgeGradle plugin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     kotlin("jvm") version "1.9.24"
-    id("net.minecraftforge.gradle") version "[6.0,6.2)"
+    id("net.minecraftforge.gradle") version "6.0.43"
 }
 
 val modVersion: String by project


### PR DESCRIPTION
## Summary
- pin ForgeGradle plugin to version 6.0.43 instead of using a range

## Testing
- ⚠️ `gradle help` *(command started but was interrupted due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_b_689e57bc36ac8329831e4f7967118a0f