### PR TITLE
Make mavenLocal optional

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,9 @@ minecraft {
 }
 
 repositories {
-    mavenLocal()
+    if (project.hasProperty("useMavenLocal")) {
+        mavenLocal()
+    }
     mavenCentral()
     maven("https://maven.minecraftforge.net")
 }


### PR DESCRIPTION
## Summary
- Wrap `mavenLocal()` in a property check so it is only used when `useMavenLocal` is set

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_b_689e5920c9ac8329a5d7c8270ca92fd4