### PR TITLE
Add EventEmitter utility

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/utilities/EventEmitter.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/EventEmitter.kt
@@ -1,0 +1,18 @@
+package com.heledron.spideranimation.utilities
+
+import java.io.Closeable
+import java.util.concurrent.CopyOnWriteArrayList
+
+class EventEmitter {
+    private val listeners = CopyOnWriteArrayList<() -> Unit>()
+
+    fun listen(listener: () -> Unit): Closeable {
+        listeners += listener
+        return Closeable { listeners.remove(listener) }
+    }
+
+    fun emit() {
+        for (listener in listeners) listener()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add thread-safe `EventEmitter` for registering and firing listeners

## Testing
- `gradle build` *(fails: Could not find net.minecraftforge:forge:1.20.1-47.3.0_mapped_official_1.20.1)*

------
https://chatgpt.com/codex/tasks/task_b_68a00104c350832980fc6f99863b451f