### PR TITLE
Add SeriesScheduler utility

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/utilities/SeriesScheduler.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/SeriesScheduler.kt
@@ -1,0 +1,13 @@
+package com.heledron.spideranimation.utilities
+
+class SeriesScheduler {
+    var time: Long = 0
+
+    fun sleep(duration: Long) = apply {
+        time += duration
+    }
+
+    fun run(task: () -> Unit) = apply {
+        Scheduler.runLater(time, task)
+    }
+}


### PR DESCRIPTION
## Summary
- add SeriesScheduler helper to chain sleeps and tasks

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_b_68a00832ead883298ef47c288bc70260