### PR TITLE
Expose rendered entities map in MultiEntityRenderer

### DIFF
--- a/src/main/kotlin/com/heledron/spideranimation/utilities/EntityRenderer.kt
+++ b/src/main/kotlin/com/heledron/spideranimation/utilities/EntityRenderer.kt
@@ -222,6 +222,11 @@ class MultiEntityRenderer : Closeable {
     private val groups = mutableMapOf<Any, GroupEntityRenderer>()
     private val used = mutableSetOf<Any>()
 
+    val rendered: Map<Any, Entity>
+        get() = groups.flatMap { (id, grp) ->
+            grp.rendered.map { id to it.value }
+        }.toMap()
+
     /** Render the given [group] associated with [id]. */
     fun render(id: Any, group: RenderEntityGroup) {
         val renderer = groups.getOrPut(id) { GroupEntityRenderer() }


### PR DESCRIPTION
## Summary
- Add `rendered` property to `MultiEntityRenderer` to expose aggregated entity map for all groups

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching languageVersion=17; toolchain download repositories not configured)*

------
https://chatgpt.com/codex/tasks/task_b_68a00ca3d85c8329965f835fb1abf705