### PR TITLE
Add gait and utility tests

### DIFF
--- a/src/test/kotlin/com/heledron/spideranimation/spider/GaitTest.kt
+++ b/src/test/kotlin/com/heledron/spideranimation/spider/GaitTest.kt
@@ -1,0 +1,31 @@
+package com.heledron.spideranimation.spider
+
+import com.heledron.spideranimation.spider.configuration.Gait
+import com.heledron.spideranimation.spider.configuration.LerpGait
+import com.heledron.spideranimation.utilities.SplitDistance
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GaitTest {
+    @Test
+    fun `lerp gait interpolates body height and trigger zone`() {
+        val start = LerpGait(1.0, SplitDistance(0.5, 1.0))
+        val end = LerpGait(3.0, SplitDistance(1.5, 2.0))
+        start.lerp(end, 0.5)
+        assertEquals(2.0, start.bodyHeight, 1e-6)
+        assertEquals(1.0, start.triggerZone.horizontal, 1e-6)
+        assertEquals(1.5, start.triggerZone.vertical, 1e-6)
+    }
+
+    @Test
+    fun `scaling gait updates related properties`() {
+        val gait = Gait.defaultWalk()
+        val originalSpeed = gait.maxSpeed
+        val originalLift = gait.legLiftHeight
+        val originalComfort = gait.comfortZone.vertical
+        gait.scale(2.0)
+        assertEquals(originalSpeed * 2, gait.maxSpeed, 1e-6)
+        assertEquals(originalLift * 2, gait.legLiftHeight, 1e-6)
+        assertEquals(originalComfort * 2, gait.comfortZone.vertical, 1e-6)
+    }
+}

--- a/src/test/kotlin/com/heledron/spideranimation/utilities/EventEmitterTest.kt
+++ b/src/test/kotlin/com/heledron/spideranimation/utilities/EventEmitterTest.kt
@@ -1,0 +1,18 @@
+package com.heledron.spideranimation.utilities
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EventEmitterTest {
+    @Test
+    fun `listeners are invoked and can be removed`() {
+        val emitter = EventEmitter()
+        var count = 0
+        val handle = emitter.listen { count++ }
+        emitter.emit()
+        assertEquals(1, count)
+        handle.close()
+        emitter.emit()
+        assertEquals(1, count)
+    }
+}

--- a/src/test/kotlin/com/heledron/spideranimation/utilities/RGBTest.kt
+++ b/src/test/kotlin/com/heledron/spideranimation/utilities/RGBTest.kt
@@ -1,0 +1,25 @@
+package com.heledron.spideranimation.utilities
+
+import net.minecraft.world.phys.Vec3
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RGBTest {
+    @Test
+    fun `withBrightness scales components`() {
+        val color = RGB(100, 50, 0)
+        val dimmed = color.withBrightness(7)
+        val expectedFactor = 7.0 / 15.0
+        assertEquals((100 * expectedFactor).toInt(), dimmed.r)
+        assertEquals((50 * expectedFactor).toInt(), dimmed.g)
+        assertEquals((0 * expectedFactor).toInt(), dimmed.b)
+    }
+
+    @Test
+    fun `conversion to and from Vec3 preserves values`() {
+        val color = RGB(10, 20, 30)
+        val vec = color.toVec3()
+        assertEquals(Vec3(10.0, 20.0, 30.0), vec)
+        assertEquals(color, vec.toRGB())
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for spider gait scaling and interpolation
- cover EventEmitter listener removal
- verify RGB brightness and Vec3 conversions

## Testing
- `./gradlew test` *(fails: Could not find net.minecraftforge:forge:1.20.1-47.3.0_mapped_official_1.20.1)*

------
https://chatgpt.com/codex/tasks/task_b_68a01abcc764832992b6f89be1cf22c1